### PR TITLE
headers: Remove loader/layer dependency

### DIFF
--- a/include/vulkan/vk_layer.h
+++ b/include/vulkan/vk_layer.h
@@ -35,9 +35,6 @@
 #define VK_LAYER_EXPORT
 #endif
 
-// Definition for VkLayerDispatchTable and VkLayerInstanceDispatchTable now appear in externally generated header
-#include "vk_layer_dispatch_table.h"
-
 #define MAX_NUM_UNKNOWN_EXTS 250
 
  // Loader-Layer version negotiation API.  Versions add the following features:
@@ -49,6 +46,9 @@
 #define MIN_SUPPORTED_LOADER_LAYER_INTERFACE_VERSION 1
 
 #define VK_CURRENT_CHAIN_VERSION 1
+
+// Typedef for use in the interfaces below
+typedef PFN_vkVoidFunction (VKAPI_PTR *PFN_GetPhysicalDeviceProcAddr)(VkInstance instance, const char* pName);
 
 // Version negotiation values
 typedef enum VkNegotiateLayerStructType {


### PR DESCRIPTION
The header `vk_layer.h` included `vk_layer_dispatch_table.h`, which is not present in this repo. Instead, it had to be generated from either the Vulkan-Loader or Vulkan-ValidationLayers repo. This change removes that dependency.

Note that merging this change right now will break the Vulkan-Loader and Vulkan-ValidationLayer repos as they use the contents of `vk_layer_dispatch_table.h` in a few places, while only including `vk_layer.h`. I will open pull requests in those repos shortly that address this problem and I'll link to them from this PR once I do.

Update: The PRs that this depends on are:
- KhronosGroup/Vulkan-Loader#48
- KhronosGroup/Vulkan-ValidationLayers#225