### PR TITLE
Add some missing "optional" markers

### DIFF
--- a/registry/vk.xml
+++ b/registry/vk.xml
@@ -742,14 +742,14 @@ server.
             <member><type>VkDeviceSize</type>           <name>maxResourceSize</name><comment>max size (in bytes) of this resource type</comment></member>
         </type>
         <type category="struct" name="VkDescriptorBufferInfo">
-            <member><type>VkBuffer</type>               <name>buffer</name><comment>Buffer used for this descriptor slot when the descriptor is UNIFORM_BUFFER[_DYNAMIC] or STORAGE_BUFFER[_DYNAMIC]. VK_NULL_HANDLE otherwise.</comment></member>
+            <member optional="true"><type>VkBuffer</type>               <name>buffer</name><comment>Buffer used for this descriptor slot when the descriptor is UNIFORM_BUFFER[_DYNAMIC] or STORAGE_BUFFER[_DYNAMIC]. VK_NULL_HANDLE otherwise.</comment></member>
             <member><type>VkDeviceSize</type>           <name>offset</name><comment>Base offset from buffer start in bytes to update in the descriptor set.</comment></member>
             <member><type>VkDeviceSize</type>           <name>range</name><comment>Size in bytes of the buffer resource for this descriptor update.</comment></member>
         </type>
         <type category="struct" name="VkDescriptorImageInfo">
-            <member noautovalidity="true"><type>VkSampler</type>       <name>sampler</name><comment>Sampler to write to the descriptor in case it is a SAMPLER or COMBINED_IMAGE_SAMPLER descriptor. Ignored otherwise.</comment></member>
-            <member noautovalidity="true"><type>VkImageView</type>     <name>imageView</name><comment>Image view to write to the descriptor in case it is a SAMPLED_IMAGE, STORAGE_IMAGE, COMBINED_IMAGE_SAMPLER, or INPUT_ATTACHMENT descriptor. Ignored otherwise.</comment></member>
-            <member noautovalidity="true"><type>VkImageLayout</type>   <name>imageLayout</name><comment>Layout the image is expected to be in when accessed using this descriptor (only used if imageView is not VK_NULL_HANDLE).</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkSampler</type>       <name>sampler</name><comment>Sampler to write to the descriptor in case it is a SAMPLER or COMBINED_IMAGE_SAMPLER descriptor. Ignored otherwise.</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkImageView</type>     <name>imageView</name><comment>Image view to write to the descriptor in case it is a SAMPLED_IMAGE, STORAGE_IMAGE, COMBINED_IMAGE_SAMPLER, or INPUT_ATTACHMENT descriptor. Ignored otherwise.</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkImageLayout</type>   <name>imageLayout</name><comment>Layout the image is expected to be in when accessed using this descriptor (only used if imageView is not VK_NULL_HANDLE).</comment></member>
         </type>
         <type category="struct" name="VkWriteDescriptorSet">
             <member values="VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET"><type>VkStructureType</type> <name>sType</name></member>
@@ -1558,7 +1558,7 @@ server.
             <member><type>VkBool32</type>                         <name>persistentContent</name><comment>VK_TRUE if this is a "smart" display that supports self-refresh/internal buffering.</comment></member>
         </type>
         <type category="struct" name="VkDisplayPlanePropertiesKHR" returnedonly="true">
-            <member><type>VkDisplayKHR</type>                     <name>currentDisplay</name><comment>Display the plane is currently associated with.  Will be VK_NULL_HANDLE if the plane is not in use.</comment></member>
+            <member optional="true"><type>VkDisplayKHR</type>                     <name>currentDisplay</name><comment>Display the plane is currently associated with.  Will be VK_NULL_HANDLE if the plane is not in use.</comment></member>
             <member><type>uint32_t</type>                         <name>currentStackIndex</name><comment>Current z-order of the plane.</comment></member>
         </type>
         <type category="struct" name="VkDisplayModeParametersKHR">


### PR DESCRIPTION
The comments on these members suggest that it is sometimes legal for them to contain `VK_NULL_HANDLE`, or in some cases an undefined value. Unless I've misunderstood the schema, it seems like they should therefore be marked as optional.