### PR TITLE
headers: Update to Vulkan header version 1.1.87

### DIFF
--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -24,6 +24,10 @@
 #include "vulkan_android.h"
 #endif
 
+#ifdef VK_USE_PLATFORM_FUCHSIA
+#include <zircon/types.h>
+#include "vulkan_fuchsia.h"
+#endif
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
 #include "vulkan_ios.h"

--- a/include/vulkan/vulkan.hpp
+++ b/include/vulkan/vulkan.hpp
@@ -70,7 +70,7 @@
   #undef MemoryBarrier
 #endif
 
-static_assert( VK_HEADER_VERSION ==  85 , "Wrong VK_HEADER_VERSION!" );
+static_assert( VK_HEADER_VERSION ==  87 , "Wrong VK_HEADER_VERSION!" );
 
 // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
 // To enable this feature on 32-bit platforms please define VULKAN_HPP_TYPESAFE_CONVERSION
@@ -1185,9 +1185,9 @@ public:
   {
     return ::vkCmdBlitImage( commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
   }
-  void vkCmdBuildAccelerationStructureNVX( VkCommandBuffer cmdBuf, VkAccelerationStructureTypeNVX type, uint32_t instanceCount, VkBuffer instanceData, VkDeviceSize instanceOffset, uint32_t geometryCount, const VkGeometryNVX* pGeometries, VkBuildAccelerationStructureFlagsNVX flags, VkBool32 update, VkAccelerationStructureNVX dst, VkAccelerationStructureNVX src, VkBuffer scratch, VkDeviceSize scratchOffset  ) const
+  void vkCmdBuildAccelerationStructureNVX( VkCommandBuffer commandBuffer, VkAccelerationStructureTypeNVX type, uint32_t instanceCount, VkBuffer instanceData, VkDeviceSize instanceOffset, uint32_t geometryCount, const VkGeometryNVX* pGeometries, VkBuildAccelerationStructureFlagsNVX flags, VkBool32 update, VkAccelerationStructureNVX dst, VkAccelerationStructureNVX src, VkBuffer scratch, VkDeviceSize scratchOffset  ) const
   {
-    return ::vkCmdBuildAccelerationStructureNVX( cmdBuf, type, instanceCount, instanceData, instanceOffset, geometryCount, pGeometries, flags, update, dst, src, scratch, scratchOffset);
+    return ::vkCmdBuildAccelerationStructureNVX( commandBuffer, type, instanceCount, instanceData, instanceOffset, geometryCount, pGeometries, flags, update, dst, src, scratch, scratchOffset);
   }
   void vkCmdClearAttachments( VkCommandBuffer commandBuffer, uint32_t attachmentCount, const VkClearAttachment* pAttachments, uint32_t rectCount, const VkClearRect* pRects  ) const
   {
@@ -1201,9 +1201,9 @@ public:
   {
     return ::vkCmdClearDepthStencilImage( commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
   }
-  void vkCmdCopyAccelerationStructureNVX( VkCommandBuffer cmdBuf, VkAccelerationStructureNVX dst, VkAccelerationStructureNVX src, VkCopyAccelerationStructureModeNVX mode  ) const
+  void vkCmdCopyAccelerationStructureNVX( VkCommandBuffer commandBuffer, VkAccelerationStructureNVX dst, VkAccelerationStructureNVX src, VkCopyAccelerationStructureModeNVX mode  ) const
   {
-    return ::vkCmdCopyAccelerationStructureNVX( cmdBuf, dst, src, mode);
+    return ::vkCmdCopyAccelerationStructureNVX( commandBuffer, dst, src, mode);
   }
   void vkCmdCopyBuffer( VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount, const VkBufferCopy* pRegions  ) const
   {
@@ -1449,9 +1449,9 @@ public:
   {
     return ::vkCmdSetViewportWScalingNV( commandBuffer, firstViewport, viewportCount, pViewportWScalings);
   }
-  void vkCmdTraceRaysNVX( VkCommandBuffer cmdBuf, VkBuffer raygenShaderBindingTableBuffer, VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer, VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride, VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset, VkDeviceSize hitShaderBindingStride, uint32_t width, uint32_t height  ) const
+  void vkCmdTraceRaysNVX( VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer, VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer, VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride, VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset, VkDeviceSize hitShaderBindingStride, uint32_t width, uint32_t height  ) const
   {
-    return ::vkCmdTraceRaysNVX( cmdBuf, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, width, height);
+    return ::vkCmdTraceRaysNVX( commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, width, height);
   }
   void vkCmdUpdateBuffer( VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize dataSize, const void* pData  ) const
   {
@@ -1461,9 +1461,9 @@ public:
   {
     return ::vkCmdWaitEvents( commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
   }
-  void vkCmdWriteAccelerationStructurePropertiesNVX( VkCommandBuffer cmdBuf, VkAccelerationStructureNVX accelerationStructure, VkQueryType queryType, VkQueryPool queryPool, uint32_t query  ) const
+  void vkCmdWriteAccelerationStructurePropertiesNVX( VkCommandBuffer commandBuffer, VkAccelerationStructureNVX accelerationStructure, VkQueryType queryType, VkQueryPool queryPool, uint32_t query  ) const
   {
-    return ::vkCmdWriteAccelerationStructurePropertiesNVX( cmdBuf, accelerationStructure, queryType, queryPool, query);
+    return ::vkCmdWriteAccelerationStructurePropertiesNVX( commandBuffer, accelerationStructure, queryType, queryPool, query);
   }
   void vkCmdWriteBufferMarkerAMD( VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage, VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker  ) const
   {
@@ -1565,6 +1565,12 @@ public:
   {
     return ::vkCreateImage( device, pCreateInfo, pAllocator, pImage);
   }
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+  VkResult vkCreateImagePipeSurfaceFUCHSIA( VkInstance instance, const VkImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface  ) const
+  {
+    return ::vkCreateImagePipeSurfaceFUCHSIA( instance, pCreateInfo, pAllocator, pSurface);
+  }
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
   VkResult vkCreateImageView( VkDevice device, const VkImageViewCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkImageView* pView  ) const
   {
     return ::vkCreateImageView( device, pCreateInfo, pAllocator, pView);
@@ -2841,6 +2847,16 @@ public:
 #ifdef VK_USE_PLATFORM_MACOS_MVK
   using MacOSSurfaceCreateFlagsMVK = Flags<MacOSSurfaceCreateFlagBitsMVK, VkMacOSSurfaceCreateFlagsMVK>;
 #endif /*VK_USE_PLATFORM_MACOS_MVK*/
+
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+  enum class ImagePipeSurfaceCreateFlagBitsFUCHSIA
+  {
+  };
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
+
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+  using ImagePipeSurfaceCreateFlagsFUCHSIA = Flags<ImagePipeSurfaceCreateFlagBitsFUCHSIA, VkImagePipeSurfaceCreateFlagsFUCHSIA>;
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
 
   enum class CommandPoolTrimFlagBits
   {
@@ -7143,6 +7159,83 @@ public:
   };
   static_assert( sizeof( DisplayModePropertiesKHR ) == sizeof( VkDisplayModePropertiesKHR ), "struct and wrapper have different size!" );
 
+  struct ConformanceVersionKHR
+  {
+    ConformanceVersionKHR( uint8_t major_ = 0,
+                           uint8_t minor_ = 0,
+                           uint8_t subminor_ = 0,
+                           uint8_t patch_ = 0 )
+      : major( major_ )
+      , minor( minor_ )
+      , subminor( subminor_ )
+      , patch( patch_ )
+    {
+    }
+
+    ConformanceVersionKHR( VkConformanceVersionKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( ConformanceVersionKHR ) );
+    }
+
+    ConformanceVersionKHR& operator=( VkConformanceVersionKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( ConformanceVersionKHR ) );
+      return *this;
+    }
+    ConformanceVersionKHR& setMajor( uint8_t major_ )
+    {
+      major = major_;
+      return *this;
+    }
+
+    ConformanceVersionKHR& setMinor( uint8_t minor_ )
+    {
+      minor = minor_;
+      return *this;
+    }
+
+    ConformanceVersionKHR& setSubminor( uint8_t subminor_ )
+    {
+      subminor = subminor_;
+      return *this;
+    }
+
+    ConformanceVersionKHR& setPatch( uint8_t patch_ )
+    {
+      patch = patch_;
+      return *this;
+    }
+
+    operator VkConformanceVersionKHR const&() const
+    {
+      return *reinterpret_cast<const VkConformanceVersionKHR*>(this);
+    }
+
+    operator VkConformanceVersionKHR &()
+    {
+      return *reinterpret_cast<VkConformanceVersionKHR*>(this);
+    }
+
+    bool operator==( ConformanceVersionKHR const& rhs ) const
+    {
+      return ( major == rhs.major )
+          && ( minor == rhs.minor )
+          && ( subminor == rhs.subminor )
+          && ( patch == rhs.patch );
+    }
+
+    bool operator!=( ConformanceVersionKHR const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+    uint8_t major;
+    uint8_t minor;
+    uint8_t subminor;
+    uint8_t patch;
+  };
+  static_assert( sizeof( ConformanceVersionKHR ) == sizeof( VkConformanceVersionKHR ), "struct and wrapper have different size!" );
+
   struct RectLayerKHR
   {
     RectLayerKHR( Offset2D offset_ = Offset2D(),
@@ -9344,10 +9437,12 @@ public:
     eImportMemoryHostPointerInfoEXT = VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT,
     eMemoryHostPointerPropertiesEXT = VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT,
     ePhysicalDeviceExternalMemoryHostPropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT,
+    ePhysicalDeviceShaderAtomicInt64FeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR,
     ePhysicalDeviceShaderCorePropertiesAMD = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD,
     ePhysicalDeviceVertexAttributeDivisorPropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT,
     ePipelineVertexInputDivisorStateCreateInfoEXT = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT,
     ePhysicalDeviceVertexAttributeDivisorFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT,
+    ePhysicalDeviceDriverPropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR,
     ePhysicalDeviceComputeShaderDerivativesFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV,
     ePhysicalDeviceMeshShaderFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV,
     ePhysicalDeviceMeshShaderPropertiesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV,
@@ -9357,7 +9452,8 @@ public:
     ePhysicalDeviceExclusiveScissorFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV,
     eCheckpointDataNV = VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV,
     eQueueFamilyCheckpointPropertiesNV = VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV,
-    ePhysicalDeviceVulkanMemoryModelFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR
+    ePhysicalDeviceVulkanMemoryModelFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR,
+    eImagepipeSurfaceCreateInfoFUCHSIA = VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA
   };
 
   struct ApplicationInfo
@@ -12304,6 +12400,78 @@ public:
   static_assert( sizeof( XcbSurfaceCreateInfoKHR ) == sizeof( VkXcbSurfaceCreateInfoKHR ), "struct and wrapper have different size!" );
 #endif /*VK_USE_PLATFORM_XCB_KHR*/
 
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+  struct ImagePipeSurfaceCreateInfoFUCHSIA
+  {
+    ImagePipeSurfaceCreateInfoFUCHSIA( ImagePipeSurfaceCreateFlagsFUCHSIA flags_ = ImagePipeSurfaceCreateFlagsFUCHSIA(),
+                                       zx_handle_t imagePipeHandle_ = 0 )
+      : flags( flags_ )
+      , imagePipeHandle( imagePipeHandle_ )
+    {
+    }
+
+    ImagePipeSurfaceCreateInfoFUCHSIA( VkImagePipeSurfaceCreateInfoFUCHSIA const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( ImagePipeSurfaceCreateInfoFUCHSIA ) );
+    }
+
+    ImagePipeSurfaceCreateInfoFUCHSIA& operator=( VkImagePipeSurfaceCreateInfoFUCHSIA const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( ImagePipeSurfaceCreateInfoFUCHSIA ) );
+      return *this;
+    }
+    ImagePipeSurfaceCreateInfoFUCHSIA& setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    ImagePipeSurfaceCreateInfoFUCHSIA& setFlags( ImagePipeSurfaceCreateFlagsFUCHSIA flags_ )
+    {
+      flags = flags_;
+      return *this;
+    }
+
+    ImagePipeSurfaceCreateInfoFUCHSIA& setImagePipeHandle( zx_handle_t imagePipeHandle_ )
+    {
+      imagePipeHandle = imagePipeHandle_;
+      return *this;
+    }
+
+    operator VkImagePipeSurfaceCreateInfoFUCHSIA const&() const
+    {
+      return *reinterpret_cast<const VkImagePipeSurfaceCreateInfoFUCHSIA*>(this);
+    }
+
+    operator VkImagePipeSurfaceCreateInfoFUCHSIA &()
+    {
+      return *reinterpret_cast<VkImagePipeSurfaceCreateInfoFUCHSIA*>(this);
+    }
+
+    bool operator==( ImagePipeSurfaceCreateInfoFUCHSIA const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( flags == rhs.flags )
+          && ( imagePipeHandle == rhs.imagePipeHandle );
+    }
+
+    bool operator!=( ImagePipeSurfaceCreateInfoFUCHSIA const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eImagepipeSurfaceCreateInfoFUCHSIA;
+
+  public:
+    const void* pNext = nullptr;
+    ImagePipeSurfaceCreateFlagsFUCHSIA flags;
+    zx_handle_t imagePipeHandle;
+  };
+  static_assert( sizeof( ImagePipeSurfaceCreateInfoFUCHSIA ) == sizeof( VkImagePipeSurfaceCreateInfoFUCHSIA ), "struct and wrapper have different size!" );
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
+
   struct DebugMarkerMarkerInfoEXT
   {
     DebugMarkerMarkerInfoEXT( const char* pMarkerName_ = nullptr,
@@ -13119,6 +13287,45 @@ public:
     uint32_t maxPushDescriptors;
   };
   static_assert( sizeof( PhysicalDevicePushDescriptorPropertiesKHR ) == sizeof( VkPhysicalDevicePushDescriptorPropertiesKHR ), "struct and wrapper have different size!" );
+
+  struct PhysicalDeviceDriverPropertiesKHR
+  {
+    operator VkPhysicalDeviceDriverPropertiesKHR const&() const
+    {
+      return *reinterpret_cast<const VkPhysicalDeviceDriverPropertiesKHR*>(this);
+    }
+
+    operator VkPhysicalDeviceDriverPropertiesKHR &()
+    {
+      return *reinterpret_cast<VkPhysicalDeviceDriverPropertiesKHR*>(this);
+    }
+
+    bool operator==( PhysicalDeviceDriverPropertiesKHR const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( driverID == rhs.driverID )
+          && ( memcmp( driverName, rhs.driverName, VK_MAX_DRIVER_NAME_SIZE_KHR * sizeof( char ) ) == 0 )
+          && ( memcmp( driverInfo, rhs.driverInfo, VK_MAX_DRIVER_INFO_SIZE_KHR * sizeof( char ) ) == 0 )
+          && ( conformanceVersion == rhs.conformanceVersion );
+    }
+
+    bool operator!=( PhysicalDeviceDriverPropertiesKHR const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::ePhysicalDeviceDriverPropertiesKHR;
+
+  public:
+    void* pNext = nullptr;
+    uint32_t driverID;
+    char driverName[VK_MAX_DRIVER_NAME_SIZE_KHR];
+    char driverInfo[VK_MAX_DRIVER_INFO_SIZE_KHR];
+    ConformanceVersionKHR conformanceVersion;
+  };
+  static_assert( sizeof( PhysicalDeviceDriverPropertiesKHR ) == sizeof( VkPhysicalDeviceDriverPropertiesKHR ), "struct and wrapper have different size!" );
 
   struct PresentRegionsKHR
   {
@@ -18758,6 +18965,76 @@ public:
     Bool32 vulkanMemoryModelDeviceScope;
   };
   static_assert( sizeof( PhysicalDeviceVulkanMemoryModelFeaturesKHR ) == sizeof( VkPhysicalDeviceVulkanMemoryModelFeaturesKHR ), "struct and wrapper have different size!" );
+
+  struct PhysicalDeviceShaderAtomicInt64FeaturesKHR
+  {
+    PhysicalDeviceShaderAtomicInt64FeaturesKHR( Bool32 shaderBufferInt64Atomics_ = 0,
+                                                Bool32 shaderSharedInt64Atomics_ = 0 )
+      : shaderBufferInt64Atomics( shaderBufferInt64Atomics_ )
+      , shaderSharedInt64Atomics( shaderSharedInt64Atomics_ )
+    {
+    }
+
+    PhysicalDeviceShaderAtomicInt64FeaturesKHR( VkPhysicalDeviceShaderAtomicInt64FeaturesKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderAtomicInt64FeaturesKHR ) );
+    }
+
+    PhysicalDeviceShaderAtomicInt64FeaturesKHR& operator=( VkPhysicalDeviceShaderAtomicInt64FeaturesKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderAtomicInt64FeaturesKHR ) );
+      return *this;
+    }
+    PhysicalDeviceShaderAtomicInt64FeaturesKHR& setPNext( void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PhysicalDeviceShaderAtomicInt64FeaturesKHR& setShaderBufferInt64Atomics( Bool32 shaderBufferInt64Atomics_ )
+    {
+      shaderBufferInt64Atomics = shaderBufferInt64Atomics_;
+      return *this;
+    }
+
+    PhysicalDeviceShaderAtomicInt64FeaturesKHR& setShaderSharedInt64Atomics( Bool32 shaderSharedInt64Atomics_ )
+    {
+      shaderSharedInt64Atomics = shaderSharedInt64Atomics_;
+      return *this;
+    }
+
+    operator VkPhysicalDeviceShaderAtomicInt64FeaturesKHR const&() const
+    {
+      return *reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64FeaturesKHR*>(this);
+    }
+
+    operator VkPhysicalDeviceShaderAtomicInt64FeaturesKHR &()
+    {
+      return *reinterpret_cast<VkPhysicalDeviceShaderAtomicInt64FeaturesKHR*>(this);
+    }
+
+    bool operator==( PhysicalDeviceShaderAtomicInt64FeaturesKHR const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( shaderBufferInt64Atomics == rhs.shaderBufferInt64Atomics )
+          && ( shaderSharedInt64Atomics == rhs.shaderSharedInt64Atomics );
+    }
+
+    bool operator!=( PhysicalDeviceShaderAtomicInt64FeaturesKHR const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::ePhysicalDeviceShaderAtomicInt64FeaturesKHR;
+
+  public:
+    void* pNext = nullptr;
+    Bool32 shaderBufferInt64Atomics;
+    Bool32 shaderSharedInt64Atomics;
+  };
+  static_assert( sizeof( PhysicalDeviceShaderAtomicInt64FeaturesKHR ) == sizeof( VkPhysicalDeviceShaderAtomicInt64FeaturesKHR ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceVertexAttributeDivisorFeaturesEXT
   {
@@ -35614,6 +35891,19 @@ public:
     eKazan = VK_VENDOR_ID_KAZAN
   };
 
+  enum class DriverIdKHR
+  {
+    eAmdProprietary = VK_DRIVER_ID_AMD_PROPRIETARY_KHR,
+    eAmdOpenSource = VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR,
+    eMesaRadv = VK_DRIVER_ID_MESA_RADV_KHR,
+    eNvidiaProprietary = VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR,
+    eIntelProprietaryWindows = VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR,
+    eIntelOpenSourceMesa = VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR,
+    eImaginationProprietary = VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR,
+    eQualcommProprietary = VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR,
+    eArmProprietary = VK_DRIVER_ID_ARM_PROPRIETARY_KHR
+  };
+
   enum class ConditionalRenderingFlagBitsEXT
   {
     eInverted = VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT
@@ -39963,15 +40253,15 @@ public:
     template<typename Dispatch = DispatchLoaderStatic>
     Result getRaytracingShaderHandlesNVX( Pipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    template <typename Allocator = std::allocator<uint8_t>, typename Dispatch = DispatchLoaderStatic> 
-    typename ResultValueType<std::vector<uint8_t,Allocator>>::type getRaytracingShaderHandlesNVX( Pipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, Dispatch const &d = Dispatch() ) const;
+    template <typename T, typename Dispatch = DispatchLoaderStatic>
+    ResultValueType<void>::type getRaytracingShaderHandlesNVX( Pipeline pipeline, uint32_t firstGroup, uint32_t groupCount, ArrayProxy<T> data, Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     template<typename Dispatch = DispatchLoaderStatic>
     Result getAccelerationStructureHandleNVX( AccelerationStructureNVX accelerationStructure, size_t dataSize, void* pData, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    template <typename Allocator = std::allocator<uint8_t>, typename Dispatch = DispatchLoaderStatic> 
-    typename ResultValueType<std::vector<uint8_t,Allocator>>::type getAccelerationStructureHandleNVX( AccelerationStructureNVX accelerationStructure, size_t dataSize, Dispatch const &d = Dispatch() ) const;
+    template <typename T, typename Dispatch = DispatchLoaderStatic>
+    ResultValueType<void>::type getAccelerationStructureHandleNVX( AccelerationStructureNVX accelerationStructure, ArrayProxy<T> data, Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     template<typename Dispatch = DispatchLoaderStatic>
@@ -43186,12 +43476,11 @@ public:
     return static_cast<Result>( d.vkGetRaytracingShaderHandlesNVX( m_device, static_cast<VkPipeline>( pipeline ), firstGroup, groupCount, dataSize, pData ) );
   }
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template <typename Allocator, typename Dispatch> 
-  VULKAN_HPP_INLINE typename ResultValueType<std::vector<uint8_t,Allocator>>::type Device::getRaytracingShaderHandlesNVX( Pipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, Dispatch const &d ) const
+  template <typename T, typename Dispatch>
+  VULKAN_HPP_INLINE ResultValueType<void>::type Device::getRaytracingShaderHandlesNVX( Pipeline pipeline, uint32_t firstGroup, uint32_t groupCount, ArrayProxy<T> data, Dispatch const &d ) const
   {
-    std::vector<uint8_t,Allocator> data( dataSize );
-    Result result = static_cast<Result>( d.vkGetRaytracingShaderHandlesNVX( m_device, static_cast<VkPipeline>( pipeline ), firstGroup, groupCount, data.size() * sizeof( uint8_t ) , reinterpret_cast<void*>( data.data() ) ) );
-    return createResultValue( result, data, VULKAN_HPP_NAMESPACE_STRING"::Device::getRaytracingShaderHandlesNVX" );
+    Result result = static_cast<Result>( d.vkGetRaytracingShaderHandlesNVX( m_device, static_cast<VkPipeline>( pipeline ), firstGroup, groupCount, data.size() * sizeof( T ) , reinterpret_cast<void*>( data.data() ) ) );
+    return createResultValue( result, VULKAN_HPP_NAMESPACE_STRING"::Device::getRaytracingShaderHandlesNVX" );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -43201,12 +43490,11 @@ public:
     return static_cast<Result>( d.vkGetAccelerationStructureHandleNVX( m_device, static_cast<VkAccelerationStructureNVX>( accelerationStructure ), dataSize, pData ) );
   }
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template <typename Allocator, typename Dispatch> 
-  VULKAN_HPP_INLINE typename ResultValueType<std::vector<uint8_t,Allocator>>::type Device::getAccelerationStructureHandleNVX( AccelerationStructureNVX accelerationStructure, size_t dataSize, Dispatch const &d ) const
+  template <typename T, typename Dispatch>
+  VULKAN_HPP_INLINE ResultValueType<void>::type Device::getAccelerationStructureHandleNVX( AccelerationStructureNVX accelerationStructure, ArrayProxy<T> data, Dispatch const &d ) const
   {
-    std::vector<uint8_t,Allocator> data( dataSize );
-    Result result = static_cast<Result>( d.vkGetAccelerationStructureHandleNVX( m_device, static_cast<VkAccelerationStructureNVX>( accelerationStructure ), data.size() * sizeof( uint8_t ) , reinterpret_cast<void*>( data.data() ) ) );
-    return createResultValue( result, data, VULKAN_HPP_NAMESPACE_STRING"::Device::getAccelerationStructureHandleNVX" );
+    Result result = static_cast<Result>( d.vkGetAccelerationStructureHandleNVX( m_device, static_cast<VkAccelerationStructureNVX>( accelerationStructure ), data.size() * sizeof( T ) , reinterpret_cast<void*>( data.data() ) ) );
+    return createResultValue( result, VULKAN_HPP_NAMESPACE_STRING"::Device::getAccelerationStructureHandleNVX" );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -43552,6 +43840,8 @@ public:
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template<typename Dispatch = DispatchLoaderStatic>
     FormatProperties2 getFormatProperties2( Format format, Dispatch const &d = Dispatch() ) const;
+    template <typename X, typename Y, typename ...Z, typename Dispatch = DispatchLoaderStatic>
+    StructureChain<X, Y, Z...> getFormatProperties2( Format format, Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     template<typename Dispatch = DispatchLoaderStatic>
@@ -43559,6 +43849,8 @@ public:
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template<typename Dispatch = DispatchLoaderStatic>
     FormatProperties2 getFormatProperties2KHR( Format format, Dispatch const &d = Dispatch() ) const;
+    template <typename X, typename Y, typename ...Z, typename Dispatch = DispatchLoaderStatic>
+    StructureChain<X, Y, Z...> getFormatProperties2KHR( Format format, Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     template<typename Dispatch = DispatchLoaderStatic>
@@ -44409,6 +44701,14 @@ public:
     d.vkGetPhysicalDeviceFormatProperties2( m_physicalDevice, static_cast<VkFormat>( format ), reinterpret_cast<VkFormatProperties2*>( &formatProperties ) );
     return formatProperties;
   }
+  template <typename X, typename Y, typename ...Z, typename Dispatch>
+  VULKAN_HPP_INLINE StructureChain<X, Y, Z...> PhysicalDevice::getFormatProperties2( Format format, Dispatch const &d ) const
+  {
+    StructureChain<X, Y, Z...> structureChain;
+    FormatProperties2& formatProperties = structureChain.template get<FormatProperties2>();
+    d.vkGetPhysicalDeviceFormatProperties2( m_physicalDevice, static_cast<VkFormat>( format ), reinterpret_cast<VkFormatProperties2*>( &formatProperties ) );
+    return structureChain;
+  }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
   template<typename Dispatch>
@@ -44423,6 +44723,14 @@ public:
     FormatProperties2 formatProperties;
     d.vkGetPhysicalDeviceFormatProperties2KHR( m_physicalDevice, static_cast<VkFormat>( format ), reinterpret_cast<VkFormatProperties2*>( &formatProperties ) );
     return formatProperties;
+  }
+  template <typename X, typename Y, typename ...Z, typename Dispatch>
+  VULKAN_HPP_INLINE StructureChain<X, Y, Z...> PhysicalDevice::getFormatProperties2KHR( Format format, Dispatch const &d ) const
+  {
+    StructureChain<X, Y, Z...> structureChain;
+    FormatProperties2& formatProperties = structureChain.template get<FormatProperties2>();
+    d.vkGetPhysicalDeviceFormatProperties2KHR( m_physicalDevice, static_cast<VkFormat>( format ), reinterpret_cast<VkFormatProperties2*>( &formatProperties ) );
+    return structureChain;
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -45297,6 +45605,19 @@ public:
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 #endif /*VK_USE_PLATFORM_XCB_KHR*/
 
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+    template<typename Dispatch = DispatchLoaderStatic>
+    Result createImagePipeSurfaceFUCHSIA( const ImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template<typename Dispatch = DispatchLoaderStatic>
+    ResultValueType<SurfaceKHR>::type createImagePipeSurfaceFUCHSIA( const ImagePipeSurfaceCreateInfoFUCHSIA & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_NO_SMART_HANDLE
+    template<typename Dispatch = DispatchLoaderStatic>
+    typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type createImagePipeSurfaceFUCHSIAUnique( const ImagePipeSurfaceCreateInfoFUCHSIA & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
+#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
+
     template<typename Dispatch = DispatchLoaderStatic>
     Result createDebugReportCallbackEXT( const DebugReportCallbackCreateInfoEXT* pCreateInfo, const AllocationCallbacks* pAllocator, DebugReportCallbackEXT* pCallback, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -45724,6 +46045,34 @@ public:
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 #endif /*VK_USE_PLATFORM_XCB_KHR*/
+
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE Result Instance::createImagePipeSurfaceFUCHSIA( const ImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d) const
+  {
+    return static_cast<Result>( d.vkCreateImagePipeSurfaceFUCHSIA( m_instance, reinterpret_cast<const VkImagePipeSurfaceCreateInfoFUCHSIA*>( pCreateInfo ), reinterpret_cast<const VkAllocationCallbacks*>( pAllocator ), reinterpret_cast<VkSurfaceKHR*>( pSurface ) ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createImagePipeSurfaceFUCHSIA( const ImagePipeSurfaceCreateInfoFUCHSIA & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
+  {
+    SurfaceKHR surface;
+    Result result = static_cast<Result>( d.vkCreateImagePipeSurfaceFUCHSIA( m_instance, reinterpret_cast<const VkImagePipeSurfaceCreateInfoFUCHSIA*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    return createResultValue( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createImagePipeSurfaceFUCHSIA" );
+  }
+#ifndef VULKAN_HPP_NO_SMART_HANDLE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type Instance::createImagePipeSurfaceFUCHSIAUnique( const ImagePipeSurfaceCreateInfoFUCHSIA & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
+  {
+    SurfaceKHR surface;
+    Result result = static_cast<Result>( d.vkCreateImagePipeSurfaceFUCHSIA( m_instance, reinterpret_cast<const VkImagePipeSurfaceCreateInfoFUCHSIA*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+
+    ObjectDestroy<Instance,Dispatch> deleter( *this, allocator, d );
+    return createResultValue<SurfaceKHR,Dispatch>( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createImagePipeSurfaceFUCHSIAUnique", deleter );
+  }
+#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
 
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Instance::createDebugReportCallbackEXT( const DebugReportCallbackCreateInfoEXT* pCreateInfo, const AllocationCallbacks* pAllocator, DebugReportCallbackEXT* pCallback, Dispatch const &d) const
@@ -46197,6 +46546,7 @@ public:
 #endif /*VK_USE_PLATFORM_WIN32_NV*/
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceFeatures2>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDevicePushDescriptorPropertiesKHR>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceDriverPropertiesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<PresentInfoKHR, PresentRegionsKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVariablePointerFeatures>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVariablePointerFeatures>{ enum { value = true }; };
@@ -46288,6 +46638,8 @@ public:
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceConditionalRenderingFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVulkanMemoryModelFeaturesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVulkanMemoryModelFeaturesKHR>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderAtomicInt64FeaturesKHR>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderAtomicInt64FeaturesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVertexAttributeDivisorFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVertexAttributeDivisorFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<ImageViewCreateInfo, ImageViewASTCDecodeModeEXT>{ enum { value = true }; };
@@ -46774,6 +47126,20 @@ public:
     return "{}";
   }
 #endif /*VK_USE_PLATFORM_MACOS_MVK*/
+
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+  VULKAN_HPP_INLINE std::string to_string(ImagePipeSurfaceCreateFlagBitsFUCHSIA)
+  {
+    return "(void)";
+  }
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
+
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+  VULKAN_HPP_INLINE std::string to_string(ImagePipeSurfaceCreateFlagsFUCHSIA)
+  {
+    return "{}";
+  }
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
 
   VULKAN_HPP_INLINE std::string to_string(CommandPoolTrimFlagBits)
   {
@@ -47849,10 +48215,12 @@ public:
     case StructureType::eImportMemoryHostPointerInfoEXT: return "ImportMemoryHostPointerInfoEXT";
     case StructureType::eMemoryHostPointerPropertiesEXT: return "MemoryHostPointerPropertiesEXT";
     case StructureType::ePhysicalDeviceExternalMemoryHostPropertiesEXT: return "PhysicalDeviceExternalMemoryHostPropertiesEXT";
+    case StructureType::ePhysicalDeviceShaderAtomicInt64FeaturesKHR: return "PhysicalDeviceShaderAtomicInt64FeaturesKHR";
     case StructureType::ePhysicalDeviceShaderCorePropertiesAMD: return "PhysicalDeviceShaderCorePropertiesAMD";
     case StructureType::ePhysicalDeviceVertexAttributeDivisorPropertiesEXT: return "PhysicalDeviceVertexAttributeDivisorPropertiesEXT";
     case StructureType::ePipelineVertexInputDivisorStateCreateInfoEXT: return "PipelineVertexInputDivisorStateCreateInfoEXT";
     case StructureType::ePhysicalDeviceVertexAttributeDivisorFeaturesEXT: return "PhysicalDeviceVertexAttributeDivisorFeaturesEXT";
+    case StructureType::ePhysicalDeviceDriverPropertiesKHR: return "PhysicalDeviceDriverPropertiesKHR";
     case StructureType::ePhysicalDeviceComputeShaderDerivativesFeaturesNV: return "PhysicalDeviceComputeShaderDerivativesFeaturesNV";
     case StructureType::ePhysicalDeviceMeshShaderFeaturesNV: return "PhysicalDeviceMeshShaderFeaturesNV";
     case StructureType::ePhysicalDeviceMeshShaderPropertiesNV: return "PhysicalDeviceMeshShaderPropertiesNV";
@@ -47863,6 +48231,7 @@ public:
     case StructureType::eCheckpointDataNV: return "CheckpointDataNV";
     case StructureType::eQueueFamilyCheckpointPropertiesNV: return "QueueFamilyCheckpointPropertiesNV";
     case StructureType::ePhysicalDeviceVulkanMemoryModelFeaturesKHR: return "PhysicalDeviceVulkanMemoryModelFeaturesKHR";
+    case StructureType::eImagepipeSurfaceCreateInfoFUCHSIA: return "ImagepipeSurfaceCreateInfoFUCHSIA";
     default: return "invalid";
     }
   }
@@ -49740,6 +50109,23 @@ public:
     }
   }
 
+  VULKAN_HPP_INLINE std::string to_string(DriverIdKHR value)
+  {
+    switch (value)
+    {
+    case DriverIdKHR::eAmdProprietary: return "AmdProprietary";
+    case DriverIdKHR::eAmdOpenSource: return "AmdOpenSource";
+    case DriverIdKHR::eMesaRadv: return "MesaRadv";
+    case DriverIdKHR::eNvidiaProprietary: return "NvidiaProprietary";
+    case DriverIdKHR::eIntelProprietaryWindows: return "IntelProprietaryWindows";
+    case DriverIdKHR::eIntelOpenSourceMesa: return "IntelOpenSourceMesa";
+    case DriverIdKHR::eImaginationProprietary: return "ImaginationProprietary";
+    case DriverIdKHR::eQualcommProprietary: return "QualcommProprietary";
+    case DriverIdKHR::eArmProprietary: return "ArmProprietary";
+    default: return "invalid";
+    }
+  }
+
   VULKAN_HPP_INLINE std::string to_string(ConditionalRenderingFlagBitsEXT value)
   {
     switch (value)
@@ -50014,6 +50400,9 @@ public:
     PFN_vkCreateIOSSurfaceMVK vkCreateIOSSurfaceMVK = 0;
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
     PFN_vkCreateImage vkCreateImage = 0;
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+    PFN_vkCreateImagePipeSurfaceFUCHSIA vkCreateImagePipeSurfaceFUCHSIA = 0;
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
     PFN_vkCreateImageView vkCreateImageView = 0;
     PFN_vkCreateIndirectCommandsLayoutNVX vkCreateIndirectCommandsLayoutNVX = 0;
     PFN_vkCreateInstance vkCreateInstance = 0;
@@ -50287,7 +50676,7 @@ public:
       vkAcquireNextImage2KHR = PFN_vkAcquireNextImage2KHR(device ? device.getProcAddr( "vkAcquireNextImage2KHR") : instance.getProcAddr( "vkAcquireNextImage2KHR"));
       vkAcquireNextImageKHR = PFN_vkAcquireNextImageKHR(device ? device.getProcAddr( "vkAcquireNextImageKHR") : instance.getProcAddr( "vkAcquireNextImageKHR"));
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_NV
-      vkAcquireXlibDisplayEXT = PFN_vkAcquireXlibDisplayEXT(device ? device.getProcAddr( "vkAcquireXlibDisplayEXT") : instance.getProcAddr( "vkAcquireXlibDisplayEXT"));
+      vkAcquireXlibDisplayEXT = PFN_vkAcquireXlibDisplayEXT(instance.getProcAddr( "vkAcquireXlibDisplayEXT"));
 #endif /*VK_USE_PLATFORM_XLIB_XRANDR_NV*/
       vkAllocateCommandBuffers = PFN_vkAllocateCommandBuffers(device ? device.getProcAddr( "vkAllocateCommandBuffers") : instance.getProcAddr( "vkAllocateCommandBuffers"));
       vkAllocateDescriptorSets = PFN_vkAllocateDescriptorSets(device ? device.getProcAddr( "vkAllocateDescriptorSets") : instance.getProcAddr( "vkAllocateDescriptorSets"));
@@ -50398,8 +50787,8 @@ public:
       vkCreateDescriptorSetLayout = PFN_vkCreateDescriptorSetLayout(device ? device.getProcAddr( "vkCreateDescriptorSetLayout") : instance.getProcAddr( "vkCreateDescriptorSetLayout"));
       vkCreateDescriptorUpdateTemplate = PFN_vkCreateDescriptorUpdateTemplate(device ? device.getProcAddr( "vkCreateDescriptorUpdateTemplate") : instance.getProcAddr( "vkCreateDescriptorUpdateTemplate"));
       vkCreateDescriptorUpdateTemplateKHR = PFN_vkCreateDescriptorUpdateTemplateKHR(device ? device.getProcAddr( "vkCreateDescriptorUpdateTemplateKHR") : instance.getProcAddr( "vkCreateDescriptorUpdateTemplateKHR"));
-      vkCreateDevice = PFN_vkCreateDevice(device ? device.getProcAddr( "vkCreateDevice") : instance.getProcAddr( "vkCreateDevice"));
-      vkCreateDisplayModeKHR = PFN_vkCreateDisplayModeKHR(device ? device.getProcAddr( "vkCreateDisplayModeKHR") : instance.getProcAddr( "vkCreateDisplayModeKHR"));
+      vkCreateDevice = PFN_vkCreateDevice(instance.getProcAddr( "vkCreateDevice"));
+      vkCreateDisplayModeKHR = PFN_vkCreateDisplayModeKHR(instance.getProcAddr( "vkCreateDisplayModeKHR"));
       vkCreateDisplayPlaneSurfaceKHR = PFN_vkCreateDisplayPlaneSurfaceKHR(instance.getProcAddr( "vkCreateDisplayPlaneSurfaceKHR"));
       vkCreateEvent = PFN_vkCreateEvent(device ? device.getProcAddr( "vkCreateEvent") : instance.getProcAddr( "vkCreateEvent"));
       vkCreateFence = PFN_vkCreateFence(device ? device.getProcAddr( "vkCreateFence") : instance.getProcAddr( "vkCreateFence"));
@@ -50409,6 +50798,9 @@ public:
       vkCreateIOSSurfaceMVK = PFN_vkCreateIOSSurfaceMVK(instance.getProcAddr( "vkCreateIOSSurfaceMVK"));
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
       vkCreateImage = PFN_vkCreateImage(device ? device.getProcAddr( "vkCreateImage") : instance.getProcAddr( "vkCreateImage"));
+#ifdef VK_USE_PLATFORM_FUCHSIA_FUCHSIA
+      vkCreateImagePipeSurfaceFUCHSIA = PFN_vkCreateImagePipeSurfaceFUCHSIA(instance.getProcAddr( "vkCreateImagePipeSurfaceFUCHSIA"));
+#endif /*VK_USE_PLATFORM_FUCHSIA_FUCHSIA*/
       vkCreateImageView = PFN_vkCreateImageView(device ? device.getProcAddr( "vkCreateImageView") : instance.getProcAddr( "vkCreateImageView"));
       vkCreateIndirectCommandsLayoutNVX = PFN_vkCreateIndirectCommandsLayoutNVX(device ? device.getProcAddr( "vkCreateIndirectCommandsLayoutNVX") : instance.getProcAddr( "vkCreateIndirectCommandsLayoutNVX"));
       vkCreateInstance = PFN_vkCreateInstance(instance.getProcAddr( "vkCreateInstance"));
@@ -50486,8 +50878,8 @@ public:
       vkDeviceWaitIdle = PFN_vkDeviceWaitIdle(device ? device.getProcAddr( "vkDeviceWaitIdle") : instance.getProcAddr( "vkDeviceWaitIdle"));
       vkDisplayPowerControlEXT = PFN_vkDisplayPowerControlEXT(device ? device.getProcAddr( "vkDisplayPowerControlEXT") : instance.getProcAddr( "vkDisplayPowerControlEXT"));
       vkEndCommandBuffer = PFN_vkEndCommandBuffer(device ? device.getProcAddr( "vkEndCommandBuffer") : instance.getProcAddr( "vkEndCommandBuffer"));
-      vkEnumerateDeviceExtensionProperties = PFN_vkEnumerateDeviceExtensionProperties(device ? device.getProcAddr( "vkEnumerateDeviceExtensionProperties") : instance.getProcAddr( "vkEnumerateDeviceExtensionProperties"));
-      vkEnumerateDeviceLayerProperties = PFN_vkEnumerateDeviceLayerProperties(device ? device.getProcAddr( "vkEnumerateDeviceLayerProperties") : instance.getProcAddr( "vkEnumerateDeviceLayerProperties"));
+      vkEnumerateDeviceExtensionProperties = PFN_vkEnumerateDeviceExtensionProperties(instance.getProcAddr( "vkEnumerateDeviceExtensionProperties"));
+      vkEnumerateDeviceLayerProperties = PFN_vkEnumerateDeviceLayerProperties(instance.getProcAddr( "vkEnumerateDeviceLayerProperties"));
       vkEnumerateInstanceExtensionProperties = PFN_vkEnumerateInstanceExtensionProperties(instance.getProcAddr( "vkEnumerateInstanceExtensionProperties"));
       vkEnumerateInstanceLayerProperties = PFN_vkEnumerateInstanceLayerProperties(instance.getProcAddr( "vkEnumerateInstanceLayerProperties"));
       vkEnumerateInstanceVersion = PFN_vkEnumerateInstanceVersion(instance.getProcAddr( "vkEnumerateInstanceVersion"));
@@ -50517,11 +50909,11 @@ public:
       vkGetDeviceProcAddr = PFN_vkGetDeviceProcAddr(device ? device.getProcAddr( "vkGetDeviceProcAddr") : instance.getProcAddr( "vkGetDeviceProcAddr"));
       vkGetDeviceQueue = PFN_vkGetDeviceQueue(device ? device.getProcAddr( "vkGetDeviceQueue") : instance.getProcAddr( "vkGetDeviceQueue"));
       vkGetDeviceQueue2 = PFN_vkGetDeviceQueue2(device ? device.getProcAddr( "vkGetDeviceQueue2") : instance.getProcAddr( "vkGetDeviceQueue2"));
-      vkGetDisplayModeProperties2KHR = PFN_vkGetDisplayModeProperties2KHR(device ? device.getProcAddr( "vkGetDisplayModeProperties2KHR") : instance.getProcAddr( "vkGetDisplayModeProperties2KHR"));
-      vkGetDisplayModePropertiesKHR = PFN_vkGetDisplayModePropertiesKHR(device ? device.getProcAddr( "vkGetDisplayModePropertiesKHR") : instance.getProcAddr( "vkGetDisplayModePropertiesKHR"));
-      vkGetDisplayPlaneCapabilities2KHR = PFN_vkGetDisplayPlaneCapabilities2KHR(device ? device.getProcAddr( "vkGetDisplayPlaneCapabilities2KHR") : instance.getProcAddr( "vkGetDisplayPlaneCapabilities2KHR"));
-      vkGetDisplayPlaneCapabilitiesKHR = PFN_vkGetDisplayPlaneCapabilitiesKHR(device ? device.getProcAddr( "vkGetDisplayPlaneCapabilitiesKHR") : instance.getProcAddr( "vkGetDisplayPlaneCapabilitiesKHR"));
-      vkGetDisplayPlaneSupportedDisplaysKHR = PFN_vkGetDisplayPlaneSupportedDisplaysKHR(device ? device.getProcAddr( "vkGetDisplayPlaneSupportedDisplaysKHR") : instance.getProcAddr( "vkGetDisplayPlaneSupportedDisplaysKHR"));
+      vkGetDisplayModeProperties2KHR = PFN_vkGetDisplayModeProperties2KHR(instance.getProcAddr( "vkGetDisplayModeProperties2KHR"));
+      vkGetDisplayModePropertiesKHR = PFN_vkGetDisplayModePropertiesKHR(instance.getProcAddr( "vkGetDisplayModePropertiesKHR"));
+      vkGetDisplayPlaneCapabilities2KHR = PFN_vkGetDisplayPlaneCapabilities2KHR(instance.getProcAddr( "vkGetDisplayPlaneCapabilities2KHR"));
+      vkGetDisplayPlaneCapabilitiesKHR = PFN_vkGetDisplayPlaneCapabilitiesKHR(instance.getProcAddr( "vkGetDisplayPlaneCapabilitiesKHR"));
+      vkGetDisplayPlaneSupportedDisplaysKHR = PFN_vkGetDisplayPlaneSupportedDisplaysKHR(instance.getProcAddr( "vkGetDisplayPlaneSupportedDisplaysKHR"));
       vkGetEventStatus = PFN_vkGetEventStatus(device ? device.getProcAddr( "vkGetEventStatus") : instance.getProcAddr( "vkGetEventStatus"));
       vkGetFenceFdKHR = PFN_vkGetFenceFdKHR(device ? device.getProcAddr( "vkGetFenceFdKHR") : instance.getProcAddr( "vkGetFenceFdKHR"));
       vkGetFenceStatus = PFN_vkGetFenceStatus(device ? device.getProcAddr( "vkGetFenceStatus") : instance.getProcAddr( "vkGetFenceStatus"));
@@ -50552,68 +50944,68 @@ public:
       vkGetMemoryWin32HandlePropertiesKHR = PFN_vkGetMemoryWin32HandlePropertiesKHR(device ? device.getProcAddr( "vkGetMemoryWin32HandlePropertiesKHR") : instance.getProcAddr( "vkGetMemoryWin32HandlePropertiesKHR"));
 #endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkGetPastPresentationTimingGOOGLE = PFN_vkGetPastPresentationTimingGOOGLE(device ? device.getProcAddr( "vkGetPastPresentationTimingGOOGLE") : instance.getProcAddr( "vkGetPastPresentationTimingGOOGLE"));
-      vkGetPhysicalDeviceDisplayPlaneProperties2KHR = PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceDisplayPlaneProperties2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceDisplayPlaneProperties2KHR"));
-      vkGetPhysicalDeviceDisplayPlanePropertiesKHR = PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceDisplayPlanePropertiesKHR") : instance.getProcAddr( "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"));
-      vkGetPhysicalDeviceDisplayProperties2KHR = PFN_vkGetPhysicalDeviceDisplayProperties2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceDisplayProperties2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceDisplayProperties2KHR"));
-      vkGetPhysicalDeviceDisplayPropertiesKHR = PFN_vkGetPhysicalDeviceDisplayPropertiesKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceDisplayPropertiesKHR") : instance.getProcAddr( "vkGetPhysicalDeviceDisplayPropertiesKHR"));
-      vkGetPhysicalDeviceExternalBufferProperties = PFN_vkGetPhysicalDeviceExternalBufferProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceExternalBufferProperties") : instance.getProcAddr( "vkGetPhysicalDeviceExternalBufferProperties"));
-      vkGetPhysicalDeviceExternalBufferPropertiesKHR = PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceExternalBufferPropertiesKHR") : instance.getProcAddr( "vkGetPhysicalDeviceExternalBufferPropertiesKHR"));
-      vkGetPhysicalDeviceExternalFenceProperties = PFN_vkGetPhysicalDeviceExternalFenceProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceExternalFenceProperties") : instance.getProcAddr( "vkGetPhysicalDeviceExternalFenceProperties"));
-      vkGetPhysicalDeviceExternalFencePropertiesKHR = PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceExternalFencePropertiesKHR") : instance.getProcAddr( "vkGetPhysicalDeviceExternalFencePropertiesKHR"));
-      vkGetPhysicalDeviceExternalImageFormatPropertiesNV = PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(device ? device.getProcAddr( "vkGetPhysicalDeviceExternalImageFormatPropertiesNV") : instance.getProcAddr( "vkGetPhysicalDeviceExternalImageFormatPropertiesNV"));
-      vkGetPhysicalDeviceExternalSemaphoreProperties = PFN_vkGetPhysicalDeviceExternalSemaphoreProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceExternalSemaphoreProperties") : instance.getProcAddr( "vkGetPhysicalDeviceExternalSemaphoreProperties"));
-      vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR") : instance.getProcAddr( "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"));
-      vkGetPhysicalDeviceFeatures = PFN_vkGetPhysicalDeviceFeatures(device ? device.getProcAddr( "vkGetPhysicalDeviceFeatures") : instance.getProcAddr( "vkGetPhysicalDeviceFeatures"));
-      vkGetPhysicalDeviceFeatures2 = PFN_vkGetPhysicalDeviceFeatures2(device ? device.getProcAddr( "vkGetPhysicalDeviceFeatures2") : instance.getProcAddr( "vkGetPhysicalDeviceFeatures2"));
-      vkGetPhysicalDeviceFeatures2KHR = PFN_vkGetPhysicalDeviceFeatures2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceFeatures2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceFeatures2KHR"));
-      vkGetPhysicalDeviceFormatProperties = PFN_vkGetPhysicalDeviceFormatProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceFormatProperties") : instance.getProcAddr( "vkGetPhysicalDeviceFormatProperties"));
-      vkGetPhysicalDeviceFormatProperties2 = PFN_vkGetPhysicalDeviceFormatProperties2(device ? device.getProcAddr( "vkGetPhysicalDeviceFormatProperties2") : instance.getProcAddr( "vkGetPhysicalDeviceFormatProperties2"));
-      vkGetPhysicalDeviceFormatProperties2KHR = PFN_vkGetPhysicalDeviceFormatProperties2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceFormatProperties2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceFormatProperties2KHR"));
-      vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX = PFN_vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX(device ? device.getProcAddr( "vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX") : instance.getProcAddr( "vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX"));
-      vkGetPhysicalDeviceImageFormatProperties = PFN_vkGetPhysicalDeviceImageFormatProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties") : instance.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties"));
-      vkGetPhysicalDeviceImageFormatProperties2 = PFN_vkGetPhysicalDeviceImageFormatProperties2(device ? device.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties2") : instance.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties2"));
-      vkGetPhysicalDeviceImageFormatProperties2KHR = PFN_vkGetPhysicalDeviceImageFormatProperties2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties2KHR"));
-      vkGetPhysicalDeviceMemoryProperties = PFN_vkGetPhysicalDeviceMemoryProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceMemoryProperties") : instance.getProcAddr( "vkGetPhysicalDeviceMemoryProperties"));
-      vkGetPhysicalDeviceMemoryProperties2 = PFN_vkGetPhysicalDeviceMemoryProperties2(device ? device.getProcAddr( "vkGetPhysicalDeviceMemoryProperties2") : instance.getProcAddr( "vkGetPhysicalDeviceMemoryProperties2"));
-      vkGetPhysicalDeviceMemoryProperties2KHR = PFN_vkGetPhysicalDeviceMemoryProperties2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceMemoryProperties2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceMemoryProperties2KHR"));
+      vkGetPhysicalDeviceDisplayPlaneProperties2KHR = PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(instance.getProcAddr( "vkGetPhysicalDeviceDisplayPlaneProperties2KHR"));
+      vkGetPhysicalDeviceDisplayPlanePropertiesKHR = PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(instance.getProcAddr( "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"));
+      vkGetPhysicalDeviceDisplayProperties2KHR = PFN_vkGetPhysicalDeviceDisplayProperties2KHR(instance.getProcAddr( "vkGetPhysicalDeviceDisplayProperties2KHR"));
+      vkGetPhysicalDeviceDisplayPropertiesKHR = PFN_vkGetPhysicalDeviceDisplayPropertiesKHR(instance.getProcAddr( "vkGetPhysicalDeviceDisplayPropertiesKHR"));
+      vkGetPhysicalDeviceExternalBufferProperties = PFN_vkGetPhysicalDeviceExternalBufferProperties(instance.getProcAddr( "vkGetPhysicalDeviceExternalBufferProperties"));
+      vkGetPhysicalDeviceExternalBufferPropertiesKHR = PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR(instance.getProcAddr( "vkGetPhysicalDeviceExternalBufferPropertiesKHR"));
+      vkGetPhysicalDeviceExternalFenceProperties = PFN_vkGetPhysicalDeviceExternalFenceProperties(instance.getProcAddr( "vkGetPhysicalDeviceExternalFenceProperties"));
+      vkGetPhysicalDeviceExternalFencePropertiesKHR = PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR(instance.getProcAddr( "vkGetPhysicalDeviceExternalFencePropertiesKHR"));
+      vkGetPhysicalDeviceExternalImageFormatPropertiesNV = PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(instance.getProcAddr( "vkGetPhysicalDeviceExternalImageFormatPropertiesNV"));
+      vkGetPhysicalDeviceExternalSemaphoreProperties = PFN_vkGetPhysicalDeviceExternalSemaphoreProperties(instance.getProcAddr( "vkGetPhysicalDeviceExternalSemaphoreProperties"));
+      vkGetPhysicalDeviceExternalSemaphorePropertiesKHR = PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(instance.getProcAddr( "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"));
+      vkGetPhysicalDeviceFeatures = PFN_vkGetPhysicalDeviceFeatures(instance.getProcAddr( "vkGetPhysicalDeviceFeatures"));
+      vkGetPhysicalDeviceFeatures2 = PFN_vkGetPhysicalDeviceFeatures2(instance.getProcAddr( "vkGetPhysicalDeviceFeatures2"));
+      vkGetPhysicalDeviceFeatures2KHR = PFN_vkGetPhysicalDeviceFeatures2KHR(instance.getProcAddr( "vkGetPhysicalDeviceFeatures2KHR"));
+      vkGetPhysicalDeviceFormatProperties = PFN_vkGetPhysicalDeviceFormatProperties(instance.getProcAddr( "vkGetPhysicalDeviceFormatProperties"));
+      vkGetPhysicalDeviceFormatProperties2 = PFN_vkGetPhysicalDeviceFormatProperties2(instance.getProcAddr( "vkGetPhysicalDeviceFormatProperties2"));
+      vkGetPhysicalDeviceFormatProperties2KHR = PFN_vkGetPhysicalDeviceFormatProperties2KHR(instance.getProcAddr( "vkGetPhysicalDeviceFormatProperties2KHR"));
+      vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX = PFN_vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX(instance.getProcAddr( "vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX"));
+      vkGetPhysicalDeviceImageFormatProperties = PFN_vkGetPhysicalDeviceImageFormatProperties(instance.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties"));
+      vkGetPhysicalDeviceImageFormatProperties2 = PFN_vkGetPhysicalDeviceImageFormatProperties2(instance.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties2"));
+      vkGetPhysicalDeviceImageFormatProperties2KHR = PFN_vkGetPhysicalDeviceImageFormatProperties2KHR(instance.getProcAddr( "vkGetPhysicalDeviceImageFormatProperties2KHR"));
+      vkGetPhysicalDeviceMemoryProperties = PFN_vkGetPhysicalDeviceMemoryProperties(instance.getProcAddr( "vkGetPhysicalDeviceMemoryProperties"));
+      vkGetPhysicalDeviceMemoryProperties2 = PFN_vkGetPhysicalDeviceMemoryProperties2(instance.getProcAddr( "vkGetPhysicalDeviceMemoryProperties2"));
+      vkGetPhysicalDeviceMemoryProperties2KHR = PFN_vkGetPhysicalDeviceMemoryProperties2KHR(instance.getProcAddr( "vkGetPhysicalDeviceMemoryProperties2KHR"));
 #ifdef VK_USE_PLATFORM_MIR_KHR
-      vkGetPhysicalDeviceMirPresentationSupportKHR = PFN_vkGetPhysicalDeviceMirPresentationSupportKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceMirPresentationSupportKHR") : instance.getProcAddr( "vkGetPhysicalDeviceMirPresentationSupportKHR"));
+      vkGetPhysicalDeviceMirPresentationSupportKHR = PFN_vkGetPhysicalDeviceMirPresentationSupportKHR(instance.getProcAddr( "vkGetPhysicalDeviceMirPresentationSupportKHR"));
 #endif /*VK_USE_PLATFORM_MIR_KHR*/
-      vkGetPhysicalDeviceMultisamplePropertiesEXT = PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT(device ? device.getProcAddr( "vkGetPhysicalDeviceMultisamplePropertiesEXT") : instance.getProcAddr( "vkGetPhysicalDeviceMultisamplePropertiesEXT"));
-      vkGetPhysicalDevicePresentRectanglesKHR = PFN_vkGetPhysicalDevicePresentRectanglesKHR(device ? device.getProcAddr( "vkGetPhysicalDevicePresentRectanglesKHR") : instance.getProcAddr( "vkGetPhysicalDevicePresentRectanglesKHR"));
-      vkGetPhysicalDeviceProperties = PFN_vkGetPhysicalDeviceProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceProperties") : instance.getProcAddr( "vkGetPhysicalDeviceProperties"));
-      vkGetPhysicalDeviceProperties2 = PFN_vkGetPhysicalDeviceProperties2(device ? device.getProcAddr( "vkGetPhysicalDeviceProperties2") : instance.getProcAddr( "vkGetPhysicalDeviceProperties2"));
-      vkGetPhysicalDeviceProperties2KHR = PFN_vkGetPhysicalDeviceProperties2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceProperties2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceProperties2KHR"));
-      vkGetPhysicalDeviceQueueFamilyProperties = PFN_vkGetPhysicalDeviceQueueFamilyProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties") : instance.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties"));
-      vkGetPhysicalDeviceQueueFamilyProperties2 = PFN_vkGetPhysicalDeviceQueueFamilyProperties2(device ? device.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties2") : instance.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties2"));
-      vkGetPhysicalDeviceQueueFamilyProperties2KHR = PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties2KHR"));
-      vkGetPhysicalDeviceSparseImageFormatProperties = PFN_vkGetPhysicalDeviceSparseImageFormatProperties(device ? device.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties") : instance.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties"));
-      vkGetPhysicalDeviceSparseImageFormatProperties2 = PFN_vkGetPhysicalDeviceSparseImageFormatProperties2(device ? device.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties2") : instance.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties2"));
-      vkGetPhysicalDeviceSparseImageFormatProperties2KHR = PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties2KHR"));
-      vkGetPhysicalDeviceSurfaceCapabilities2EXT = PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT(device ? device.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilities2EXT") : instance.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
-      vkGetPhysicalDeviceSurfaceCapabilities2KHR = PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilities2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilities2KHR"));
-      vkGetPhysicalDeviceSurfaceCapabilitiesKHR = PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilitiesKHR") : instance.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"));
-      vkGetPhysicalDeviceSurfaceFormats2KHR = PFN_vkGetPhysicalDeviceSurfaceFormats2KHR(device ? device.getProcAddr( "vkGetPhysicalDeviceSurfaceFormats2KHR") : instance.getProcAddr( "vkGetPhysicalDeviceSurfaceFormats2KHR"));
-      vkGetPhysicalDeviceSurfaceFormatsKHR = PFN_vkGetPhysicalDeviceSurfaceFormatsKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceSurfaceFormatsKHR") : instance.getProcAddr( "vkGetPhysicalDeviceSurfaceFormatsKHR"));
-      vkGetPhysicalDeviceSurfacePresentModesKHR = PFN_vkGetPhysicalDeviceSurfacePresentModesKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceSurfacePresentModesKHR") : instance.getProcAddr( "vkGetPhysicalDeviceSurfacePresentModesKHR"));
-      vkGetPhysicalDeviceSurfaceSupportKHR = PFN_vkGetPhysicalDeviceSurfaceSupportKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceSurfaceSupportKHR") : instance.getProcAddr( "vkGetPhysicalDeviceSurfaceSupportKHR"));
+      vkGetPhysicalDeviceMultisamplePropertiesEXT = PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT(instance.getProcAddr( "vkGetPhysicalDeviceMultisamplePropertiesEXT"));
+      vkGetPhysicalDevicePresentRectanglesKHR = PFN_vkGetPhysicalDevicePresentRectanglesKHR(instance.getProcAddr( "vkGetPhysicalDevicePresentRectanglesKHR"));
+      vkGetPhysicalDeviceProperties = PFN_vkGetPhysicalDeviceProperties(instance.getProcAddr( "vkGetPhysicalDeviceProperties"));
+      vkGetPhysicalDeviceProperties2 = PFN_vkGetPhysicalDeviceProperties2(instance.getProcAddr( "vkGetPhysicalDeviceProperties2"));
+      vkGetPhysicalDeviceProperties2KHR = PFN_vkGetPhysicalDeviceProperties2KHR(instance.getProcAddr( "vkGetPhysicalDeviceProperties2KHR"));
+      vkGetPhysicalDeviceQueueFamilyProperties = PFN_vkGetPhysicalDeviceQueueFamilyProperties(instance.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties"));
+      vkGetPhysicalDeviceQueueFamilyProperties2 = PFN_vkGetPhysicalDeviceQueueFamilyProperties2(instance.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties2"));
+      vkGetPhysicalDeviceQueueFamilyProperties2KHR = PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR(instance.getProcAddr( "vkGetPhysicalDeviceQueueFamilyProperties2KHR"));
+      vkGetPhysicalDeviceSparseImageFormatProperties = PFN_vkGetPhysicalDeviceSparseImageFormatProperties(instance.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties"));
+      vkGetPhysicalDeviceSparseImageFormatProperties2 = PFN_vkGetPhysicalDeviceSparseImageFormatProperties2(instance.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties2"));
+      vkGetPhysicalDeviceSparseImageFormatProperties2KHR = PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(instance.getProcAddr( "vkGetPhysicalDeviceSparseImageFormatProperties2KHR"));
+      vkGetPhysicalDeviceSurfaceCapabilities2EXT = PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT(instance.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilities2EXT"));
+      vkGetPhysicalDeviceSurfaceCapabilities2KHR = PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR(instance.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilities2KHR"));
+      vkGetPhysicalDeviceSurfaceCapabilitiesKHR = PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(instance.getProcAddr( "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"));
+      vkGetPhysicalDeviceSurfaceFormats2KHR = PFN_vkGetPhysicalDeviceSurfaceFormats2KHR(instance.getProcAddr( "vkGetPhysicalDeviceSurfaceFormats2KHR"));
+      vkGetPhysicalDeviceSurfaceFormatsKHR = PFN_vkGetPhysicalDeviceSurfaceFormatsKHR(instance.getProcAddr( "vkGetPhysicalDeviceSurfaceFormatsKHR"));
+      vkGetPhysicalDeviceSurfacePresentModesKHR = PFN_vkGetPhysicalDeviceSurfacePresentModesKHR(instance.getProcAddr( "vkGetPhysicalDeviceSurfacePresentModesKHR"));
+      vkGetPhysicalDeviceSurfaceSupportKHR = PFN_vkGetPhysicalDeviceSurfaceSupportKHR(instance.getProcAddr( "vkGetPhysicalDeviceSurfaceSupportKHR"));
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-      vkGetPhysicalDeviceWaylandPresentationSupportKHR = PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceWaylandPresentationSupportKHR") : instance.getProcAddr( "vkGetPhysicalDeviceWaylandPresentationSupportKHR"));
+      vkGetPhysicalDeviceWaylandPresentationSupportKHR = PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR(instance.getProcAddr( "vkGetPhysicalDeviceWaylandPresentationSupportKHR"));
 #endif /*VK_USE_PLATFORM_WAYLAND_KHR*/
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-      vkGetPhysicalDeviceWin32PresentationSupportKHR = PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceWin32PresentationSupportKHR") : instance.getProcAddr( "vkGetPhysicalDeviceWin32PresentationSupportKHR"));
+      vkGetPhysicalDeviceWin32PresentationSupportKHR = PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR(instance.getProcAddr( "vkGetPhysicalDeviceWin32PresentationSupportKHR"));
 #endif /*VK_USE_PLATFORM_WIN32_KHR*/
 #ifdef VK_USE_PLATFORM_XCB_KHR
-      vkGetPhysicalDeviceXcbPresentationSupportKHR = PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceXcbPresentationSupportKHR") : instance.getProcAddr( "vkGetPhysicalDeviceXcbPresentationSupportKHR"));
+      vkGetPhysicalDeviceXcbPresentationSupportKHR = PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR(instance.getProcAddr( "vkGetPhysicalDeviceXcbPresentationSupportKHR"));
 #endif /*VK_USE_PLATFORM_XCB_KHR*/
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-      vkGetPhysicalDeviceXlibPresentationSupportKHR = PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR(device ? device.getProcAddr( "vkGetPhysicalDeviceXlibPresentationSupportKHR") : instance.getProcAddr( "vkGetPhysicalDeviceXlibPresentationSupportKHR"));
+      vkGetPhysicalDeviceXlibPresentationSupportKHR = PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR(instance.getProcAddr( "vkGetPhysicalDeviceXlibPresentationSupportKHR"));
 #endif /*VK_USE_PLATFORM_XLIB_KHR*/
       vkGetPipelineCacheData = PFN_vkGetPipelineCacheData(device ? device.getProcAddr( "vkGetPipelineCacheData") : instance.getProcAddr( "vkGetPipelineCacheData"));
       vkGetQueryPoolResults = PFN_vkGetQueryPoolResults(device ? device.getProcAddr( "vkGetQueryPoolResults") : instance.getProcAddr( "vkGetQueryPoolResults"));
       vkGetQueueCheckpointDataNV = PFN_vkGetQueueCheckpointDataNV(device ? device.getProcAddr( "vkGetQueueCheckpointDataNV") : instance.getProcAddr( "vkGetQueueCheckpointDataNV"));
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_NV
-      vkGetRandROutputDisplayEXT = PFN_vkGetRandROutputDisplayEXT(device ? device.getProcAddr( "vkGetRandROutputDisplayEXT") : instance.getProcAddr( "vkGetRandROutputDisplayEXT"));
+      vkGetRandROutputDisplayEXT = PFN_vkGetRandROutputDisplayEXT(instance.getProcAddr( "vkGetRandROutputDisplayEXT"));
 #endif /*VK_USE_PLATFORM_XLIB_XRANDR_NV*/
       vkGetRaytracingShaderHandlesNVX = PFN_vkGetRaytracingShaderHandlesNVX(device ? device.getProcAddr( "vkGetRaytracingShaderHandlesNVX") : instance.getProcAddr( "vkGetRaytracingShaderHandlesNVX"));
       vkGetRefreshCycleDurationGOOGLE = PFN_vkGetRefreshCycleDurationGOOGLE(device ? device.getProcAddr( "vkGetRefreshCycleDurationGOOGLE") : instance.getProcAddr( "vkGetRefreshCycleDurationGOOGLE"));
@@ -50649,7 +51041,7 @@ public:
       vkRegisterDeviceEventEXT = PFN_vkRegisterDeviceEventEXT(device ? device.getProcAddr( "vkRegisterDeviceEventEXT") : instance.getProcAddr( "vkRegisterDeviceEventEXT"));
       vkRegisterDisplayEventEXT = PFN_vkRegisterDisplayEventEXT(device ? device.getProcAddr( "vkRegisterDisplayEventEXT") : instance.getProcAddr( "vkRegisterDisplayEventEXT"));
       vkRegisterObjectsNVX = PFN_vkRegisterObjectsNVX(device ? device.getProcAddr( "vkRegisterObjectsNVX") : instance.getProcAddr( "vkRegisterObjectsNVX"));
-      vkReleaseDisplayEXT = PFN_vkReleaseDisplayEXT(device ? device.getProcAddr( "vkReleaseDisplayEXT") : instance.getProcAddr( "vkReleaseDisplayEXT"));
+      vkReleaseDisplayEXT = PFN_vkReleaseDisplayEXT(instance.getProcAddr( "vkReleaseDisplayEXT"));
       vkResetCommandBuffer = PFN_vkResetCommandBuffer(device ? device.getProcAddr( "vkResetCommandBuffer") : instance.getProcAddr( "vkResetCommandBuffer"));
       vkResetCommandPool = PFN_vkResetCommandPool(device ? device.getProcAddr( "vkResetCommandPool") : instance.getProcAddr( "vkResetCommandPool"));
       vkResetDescriptorPool = PFN_vkResetDescriptorPool(device ? device.getProcAddr( "vkResetDescriptorPool") : instance.getProcAddr( "vkResetDescriptorPool"));

--- a/include/vulkan/vulkan_core.h
+++ b/include/vulkan/vulkan_core.h
@@ -43,7 +43,7 @@ extern "C" {
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
 #define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
 // Version of this file
-#define VK_HEADER_VERSION 85
+#define VK_HEADER_VERSION 87
 
 
 #define VK_NULL_HANDLE 0
@@ -427,10 +427,12 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT = 1000178000,
     VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT = 1000178001,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT = 1000178002,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR = 1000180000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD = 1000185000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT = 1000190000,
     VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT = 1000190001,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT = 1000190002,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR = 1000196000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV = 1000201000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV = 1000202000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV = 1000202001,
@@ -441,6 +443,7 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV = 1000206000,
     VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV = 1000206001,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR = 1000211000,
+    VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA = 1000214000,
     VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
     VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO_KHR = VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES,
@@ -6044,6 +6047,60 @@ typedef struct VkPhysicalDevice8BitStorageFeaturesKHR {
 
 
 
+#define VK_KHR_shader_atomic_int64 1
+#define VK_KHR_SHADER_ATOMIC_INT64_SPEC_VERSION 1
+#define VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME "VK_KHR_shader_atomic_int64"
+
+typedef struct VkPhysicalDeviceShaderAtomicInt64FeaturesKHR {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           shaderBufferInt64Atomics;
+    VkBool32           shaderSharedInt64Atomics;
+} VkPhysicalDeviceShaderAtomicInt64FeaturesKHR;
+
+
+
+#define VK_KHR_driver_properties 1
+#define VK_MAX_DRIVER_NAME_SIZE_KHR       256
+#define VK_MAX_DRIVER_INFO_SIZE_KHR       256
+#define VK_KHR_DRIVER_PROPERTIES_SPEC_VERSION 1
+#define VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME "VK_KHR_driver_properties"
+
+
+typedef enum VkDriverIdKHR {
+    VK_DRIVER_ID_AMD_PROPRIETARY_KHR = 1,
+    VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR = 2,
+    VK_DRIVER_ID_MESA_RADV_KHR = 3,
+    VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR = 4,
+    VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR = 5,
+    VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR = 6,
+    VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR = 7,
+    VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR = 8,
+    VK_DRIVER_ID_ARM_PROPRIETARY_KHR = 9,
+    VK_DRIVER_ID_BEGIN_RANGE_KHR = VK_DRIVER_ID_AMD_PROPRIETARY_KHR,
+    VK_DRIVER_ID_END_RANGE_KHR = VK_DRIVER_ID_ARM_PROPRIETARY_KHR,
+    VK_DRIVER_ID_RANGE_SIZE_KHR = (VK_DRIVER_ID_ARM_PROPRIETARY_KHR - VK_DRIVER_ID_AMD_PROPRIETARY_KHR + 1),
+    VK_DRIVER_ID_MAX_ENUM_KHR = 0x7FFFFFFF
+} VkDriverIdKHR;
+
+typedef struct VkConformanceVersionKHR {
+    uint8_t    major;
+    uint8_t    minor;
+    uint8_t    subminor;
+    uint8_t    patch;
+} VkConformanceVersionKHR;
+
+typedef struct VkPhysicalDeviceDriverPropertiesKHR {
+    VkStructureType            sType;
+    void*                      pNext;
+    uint32_t                   driverID;
+    char                       driverName[VK_MAX_DRIVER_NAME_SIZE_KHR];
+    char                       driverInfo[VK_MAX_DRIVER_INFO_SIZE_KHR];
+    VkConformanceVersionKHR    conformanceVersion;
+} VkPhysicalDeviceDriverPropertiesKHR;
+
+
+
 #define VK_KHR_vulkan_memory_model 1
 #define VK_KHR_VULKAN_MEMORY_MODEL_SPEC_VERSION 2
 #define VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME "VK_KHR_vulkan_memory_model"
@@ -8044,13 +8101,13 @@ typedef void (VKAPI_PTR *PFN_vkDestroyAccelerationStructureNVX)(VkDevice device,
 typedef void (VKAPI_PTR *PFN_vkGetAccelerationStructureMemoryRequirementsNVX)(VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNVX* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements);
 typedef void (VKAPI_PTR *PFN_vkGetAccelerationStructureScratchMemoryRequirementsNVX)(VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNVX* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements);
 typedef VkResult (VKAPI_PTR *PFN_vkBindAccelerationStructureMemoryNVX)(VkDevice device, uint32_t bindInfoCount, const VkBindAccelerationStructureMemoryInfoNVX* pBindInfos);
-typedef void (VKAPI_PTR *PFN_vkCmdBuildAccelerationStructureNVX)(VkCommandBuffer cmdBuf, VkAccelerationStructureTypeNVX type, uint32_t instanceCount, VkBuffer instanceData, VkDeviceSize instanceOffset, uint32_t geometryCount, const VkGeometryNVX* pGeometries, VkBuildAccelerationStructureFlagsNVX flags, VkBool32 update, VkAccelerationStructureNVX dst, VkAccelerationStructureNVX src, VkBuffer scratch, VkDeviceSize scratchOffset);
-typedef void (VKAPI_PTR *PFN_vkCmdCopyAccelerationStructureNVX)(VkCommandBuffer cmdBuf, VkAccelerationStructureNVX dst, VkAccelerationStructureNVX src, VkCopyAccelerationStructureModeNVX mode);
-typedef void (VKAPI_PTR *PFN_vkCmdTraceRaysNVX)(VkCommandBuffer cmdBuf, VkBuffer raygenShaderBindingTableBuffer, VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer, VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride, VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset, VkDeviceSize hitShaderBindingStride, uint32_t width, uint32_t height);
+typedef void (VKAPI_PTR *PFN_vkCmdBuildAccelerationStructureNVX)(VkCommandBuffer commandBuffer, VkAccelerationStructureTypeNVX type, uint32_t instanceCount, VkBuffer instanceData, VkDeviceSize instanceOffset, uint32_t geometryCount, const VkGeometryNVX* pGeometries, VkBuildAccelerationStructureFlagsNVX flags, VkBool32 update, VkAccelerationStructureNVX dst, VkAccelerationStructureNVX src, VkBuffer scratch, VkDeviceSize scratchOffset);
+typedef void (VKAPI_PTR *PFN_vkCmdCopyAccelerationStructureNVX)(VkCommandBuffer commandBuffer, VkAccelerationStructureNVX dst, VkAccelerationStructureNVX src, VkCopyAccelerationStructureModeNVX mode);
+typedef void (VKAPI_PTR *PFN_vkCmdTraceRaysNVX)(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer, VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer, VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride, VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset, VkDeviceSize hitShaderBindingStride, uint32_t width, uint32_t height);
 typedef VkResult (VKAPI_PTR *PFN_vkCreateRaytracingPipelinesNVX)(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount, const VkRaytracingPipelineCreateInfoNVX* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines);
 typedef VkResult (VKAPI_PTR *PFN_vkGetRaytracingShaderHandlesNVX)(VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData);
 typedef VkResult (VKAPI_PTR *PFN_vkGetAccelerationStructureHandleNVX)(VkDevice device, VkAccelerationStructureNVX accelerationStructure, size_t dataSize, void* pData);
-typedef void (VKAPI_PTR *PFN_vkCmdWriteAccelerationStructurePropertiesNVX)(VkCommandBuffer cmdBuf, VkAccelerationStructureNVX accelerationStructure, VkQueryType queryType, VkQueryPool queryPool, uint32_t query);
+typedef void (VKAPI_PTR *PFN_vkCmdWriteAccelerationStructurePropertiesNVX)(VkCommandBuffer commandBuffer, VkAccelerationStructureNVX accelerationStructure, VkQueryType queryType, VkQueryPool queryPool, uint32_t query);
 typedef VkResult (VKAPI_PTR *PFN_vkCompileDeferredNVX)(VkDevice device, VkPipeline pipeline, uint32_t shader);
 
 #ifndef VK_NO_PROTOTYPES
@@ -8081,7 +8138,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkBindAccelerationStructureMemoryNVX(
     const VkBindAccelerationStructureMemoryInfoNVX* pBindInfos);
 
 VKAPI_ATTR void VKAPI_CALL vkCmdBuildAccelerationStructureNVX(
-    VkCommandBuffer                             cmdBuf,
+    VkCommandBuffer                             commandBuffer,
     VkAccelerationStructureTypeNVX              type,
     uint32_t                                    instanceCount,
     VkBuffer                                    instanceData,
@@ -8096,13 +8153,13 @@ VKAPI_ATTR void VKAPI_CALL vkCmdBuildAccelerationStructureNVX(
     VkDeviceSize                                scratchOffset);
 
 VKAPI_ATTR void VKAPI_CALL vkCmdCopyAccelerationStructureNVX(
-    VkCommandBuffer                             cmdBuf,
+    VkCommandBuffer                             commandBuffer,
     VkAccelerationStructureNVX                  dst,
     VkAccelerationStructureNVX                  src,
     VkCopyAccelerationStructureModeNVX          mode);
 
 VKAPI_ATTR void VKAPI_CALL vkCmdTraceRaysNVX(
-    VkCommandBuffer                             cmdBuf,
+    VkCommandBuffer                             commandBuffer,
     VkBuffer                                    raygenShaderBindingTableBuffer,
     VkDeviceSize                                raygenShaderBindingOffset,
     VkBuffer                                    missShaderBindingTableBuffer,
@@ -8137,7 +8194,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetAccelerationStructureHandleNVX(
     void*                                       pData);
 
 VKAPI_ATTR void VKAPI_CALL vkCmdWriteAccelerationStructurePropertiesNVX(
-    VkCommandBuffer                             cmdBuf,
+    VkCommandBuffer                             commandBuffer,
     VkAccelerationStructureNVX                  accelerationStructure,
     VkQueryType                                 queryType,
     VkQueryPool                                 queryPool,

--- a/include/vulkan/vulkan_fuchsia.h
+++ b/include/vulkan/vulkan_fuchsia.h
@@ -1,0 +1,58 @@
+#ifndef VULKAN_FUCHSIA_H_
+#define VULKAN_FUCHSIA_H_ 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+** Copyright (c) 2015-2018 The Khronos Group Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+/*
+** This header is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+
+#define VK_FUCHSIA_imagepipe_surface 1
+#define VK_FUCHSIA_IMAGEPIPE_SURFACE_SPEC_VERSION 1
+#define VK_FUCHSIA_IMAGEPIPE_SURFACE_EXTENSION_NAME "VK_FUCHSIA_imagepipe_surface"
+
+typedef VkFlags VkImagePipeSurfaceCreateFlagsFUCHSIA;
+
+typedef struct VkImagePipeSurfaceCreateInfoFUCHSIA {
+    VkStructureType                         sType;
+    const void*                             pNext;
+    VkImagePipeSurfaceCreateFlagsFUCHSIA    flags;
+    zx_handle_t                             imagePipeHandle;
+} VkImagePipeSurfaceCreateInfoFUCHSIA;
+
+
+typedef VkResult (VKAPI_PTR *PFN_vkCreateImagePipeSurfaceFUCHSIA)(VkInstance instance, const VkImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkCreateImagePipeSurfaceFUCHSIA(
+    VkInstance                                  instance,
+    const VkImagePipeSurfaceCreateInfoFUCHSIA*  pCreateInfo,
+    const VkAllocationCallbacks*                pAllocator,
+    VkSurfaceKHR*                               pSurface);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/registry/genvk.py
+++ b/registry/genvk.py
@@ -254,6 +254,7 @@ def makeGenOpts(args):
         [ 'vulkan_android.h',     [ 'VK_KHR_android_surface',
                                     'VK_ANDROID_external_memory_android_hardware_buffer'
                                                                   ], commonSuppressExtensions ],
+        [ 'vulkan_fuchsia.h',     [ 'VK_FUCHSIA_imagepipe_surface'], commonSuppressExtensions ],
         [ 'vulkan_ios.h',         [ 'VK_MVK_ios_surface'          ], commonSuppressExtensions ],
         [ 'vulkan_macos.h',       [ 'VK_MVK_macos_surface'        ], commonSuppressExtensions ],
         [ 'vulkan_mir.h',         [ 'VK_KHR_mir_surface'          ], commonSuppressExtensions ],

--- a/registry/reg.py
+++ b/registry/reg.py
@@ -502,12 +502,17 @@ class Registry:
 
         # Construct a "validextensionstructs" list for parent structures
         # based on "structextends" tags in child structures
+        disabled_types = []
+        for disabled_ext in self.reg.findall('extensions/extension[@supported="disabled"]'):
+            for type in disabled_ext.findall("*/type"):
+                disabled_types.append(type.get('name'))
         for type in self.reg.findall('types/type'):
-            parentStructs = type.get('structextends')
-            if (parentStructs != None):
-                for parent in parentStructs.split(','):
-                    # self.gen.logMsg('diag', type.get('name'), 'extends', parent)
-                    self.validextensionstructs[parent].append(type.get('name'))
+            if type.get('name') not in disabled_types:
+                parentStructs = type.get('structextends')
+                if (parentStructs != None):
+                    for parent in parentStructs.split(','):
+                        # self.gen.logMsg('diag', type.get('name'), 'extends', parent)
+                        self.validextensionstructs[parent].append(type.get('name'))
         # Sort the lists so they don't depend on the XML order
         for parent in self.validextensionstructs:
             self.validextensionstructs[parent].sort()

--- a/registry/validusage.json
+++ b/registry/validusage.json
@@ -1,9 +1,9 @@
 {
   "version info": {
     "schema version": 2,
-    "api version": "1.1.85",
-    "comment": "from git branch: master commit: 9858c1e89e21246f779226d2be779fd33bb6a50d",
-    "date": "2018-09-19 19:31:34Z"
+    "api version": "1.1.87",
+    "comment": "from git branch: master commit: 911a7646949e661b24ad6111479029ed9e841284",
+    "date": "2018-10-09 21:58:14Z"
   },
   "validation": {
     "vkGetInstanceProcAddr": {
@@ -198,7 +198,7 @@
         },
         {
           "vuid": "VUID-VkPhysicalDeviceProperties2-pNext-pNext",
-          "text": " Each <code>pNext</code> member of any structure (including this one) in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be either <code>NULL</code> or a pointer to a valid instance of <a href=\"#VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT\">VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceConservativeRasterizationPropertiesEXT\">VkPhysicalDeviceConservativeRasterizationPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceDescriptorIndexingPropertiesEXT\">VkPhysicalDeviceDescriptorIndexingPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceDiscardRectanglePropertiesEXT\">VkPhysicalDeviceDiscardRectanglePropertiesEXT</a>, <a href=\"#VkPhysicalDeviceExternalMemoryHostPropertiesEXT\">VkPhysicalDeviceExternalMemoryHostPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceIDProperties\">VkPhysicalDeviceIDProperties</a>, <a href=\"#VkPhysicalDeviceInlineUniformBlockPropertiesEXT\">VkPhysicalDeviceInlineUniformBlockPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceMaintenance3Properties\">VkPhysicalDeviceMaintenance3Properties</a>, <a href=\"#VkPhysicalDeviceMeshShaderPropertiesNV\">VkPhysicalDeviceMeshShaderPropertiesNV</a>, <a href=\"#VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX\">VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX</a>, <a href=\"#VkPhysicalDeviceMultiviewProperties\">VkPhysicalDeviceMultiviewProperties</a>, <a href=\"#VkPhysicalDevicePointClippingProperties\">VkPhysicalDevicePointClippingProperties</a>, <a href=\"#VkPhysicalDeviceProtectedMemoryProperties\">VkPhysicalDeviceProtectedMemoryProperties</a>, <a href=\"#VkPhysicalDevicePushDescriptorPropertiesKHR\">VkPhysicalDevicePushDescriptorPropertiesKHR</a>, <a href=\"#VkPhysicalDeviceRaytracingPropertiesNVX\">VkPhysicalDeviceRaytracingPropertiesNVX</a>, <a href=\"#VkPhysicalDeviceSampleLocationsPropertiesEXT\">VkPhysicalDeviceSampleLocationsPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT\">VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceShaderCorePropertiesAMD\">VkPhysicalDeviceShaderCorePropertiesAMD</a>, <a href=\"#VkPhysicalDeviceSubgroupProperties\">VkPhysicalDeviceSubgroupProperties</a>, or <a href=\"#VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT\">VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT</a>"
+          "text": " Each <code>pNext</code> member of any structure (including this one) in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be either <code>NULL</code> or a pointer to a valid instance of <a href=\"#VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT\">VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceConservativeRasterizationPropertiesEXT\">VkPhysicalDeviceConservativeRasterizationPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceDescriptorIndexingPropertiesEXT\">VkPhysicalDeviceDescriptorIndexingPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceDiscardRectanglePropertiesEXT\">VkPhysicalDeviceDiscardRectanglePropertiesEXT</a>, <a href=\"#VkPhysicalDeviceDriverPropertiesKHR\">VkPhysicalDeviceDriverPropertiesKHR</a>, <a href=\"#VkPhysicalDeviceExternalMemoryHostPropertiesEXT\">VkPhysicalDeviceExternalMemoryHostPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceIDProperties\">VkPhysicalDeviceIDProperties</a>, <a href=\"#VkPhysicalDeviceInlineUniformBlockPropertiesEXT\">VkPhysicalDeviceInlineUniformBlockPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceMaintenance3Properties\">VkPhysicalDeviceMaintenance3Properties</a>, <a href=\"#VkPhysicalDeviceMeshShaderPropertiesNV\">VkPhysicalDeviceMeshShaderPropertiesNV</a>, <a href=\"#VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX\">VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX</a>, <a href=\"#VkPhysicalDeviceMultiviewProperties\">VkPhysicalDeviceMultiviewProperties</a>, <a href=\"#VkPhysicalDevicePointClippingProperties\">VkPhysicalDevicePointClippingProperties</a>, <a href=\"#VkPhysicalDeviceProtectedMemoryProperties\">VkPhysicalDeviceProtectedMemoryProperties</a>, <a href=\"#VkPhysicalDevicePushDescriptorPropertiesKHR\">VkPhysicalDevicePushDescriptorPropertiesKHR</a>, <a href=\"#VkPhysicalDeviceRaytracingPropertiesNVX\">VkPhysicalDeviceRaytracingPropertiesNVX</a>, <a href=\"#VkPhysicalDeviceSampleLocationsPropertiesEXT\">VkPhysicalDeviceSampleLocationsPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT\">VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT</a>, <a href=\"#VkPhysicalDeviceShaderCorePropertiesAMD\">VkPhysicalDeviceShaderCorePropertiesAMD</a>, <a href=\"#VkPhysicalDeviceSubgroupProperties\">VkPhysicalDeviceSubgroupProperties</a>, or <a href=\"#VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT\">VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT</a>"
         },
         {
           "vuid": "VUID-VkPhysicalDeviceProperties2-sType-unique",
@@ -211,6 +211,14 @@
         {
           "vuid": "VUID-VkPhysicalDeviceIDProperties-sType-sType",
           "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES</code>"
+        }
+      ]
+    },
+    "VkPhysicalDeviceDriverPropertiesKHR": {
+      "(VK_VERSION_1_1,VK_KHR_get_physical_device_properties2)+(VK_KHR_driver_properties)": [
+        {
+          "vuid": "VUID-VkPhysicalDeviceDriverPropertiesKHR-sType-sType",
+          "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR</code>"
         }
       ]
     },
@@ -318,7 +326,7 @@
         },
         {
           "vuid": "VUID-VkDeviceCreateInfo-pNext-pNext",
-          "text": " Each <code>pNext</code> member of any structure (including this one) in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be either <code>NULL</code> or a pointer to a valid instance of <a href=\"#VkDeviceGroupDeviceCreateInfo\">VkDeviceGroupDeviceCreateInfo</a>, <a href=\"#VkPhysicalDevice16BitStorageFeatures\">VkPhysicalDevice16BitStorageFeatures</a>, <a href=\"#VkPhysicalDevice8BitStorageFeaturesKHR\">VkPhysicalDevice8BitStorageFeaturesKHR</a>, <a href=\"#VkPhysicalDeviceASTCDecodeFeaturesEXT\">VkPhysicalDeviceASTCDecodeFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT\">VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceComputeShaderDerivativesFeaturesNV\">VkPhysicalDeviceComputeShaderDerivativesFeaturesNV</a>, <a href=\"#VkPhysicalDeviceConditionalRenderingFeaturesEXT\">VkPhysicalDeviceConditionalRenderingFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceCornerSampledImageFeaturesNV\">VkPhysicalDeviceCornerSampledImageFeaturesNV</a>, <a href=\"#VkPhysicalDeviceDescriptorIndexingFeaturesEXT\">VkPhysicalDeviceDescriptorIndexingFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceExclusiveScissorFeaturesNV\">VkPhysicalDeviceExclusiveScissorFeaturesNV</a>, <a href=\"#VkPhysicalDeviceFeatures2\">VkPhysicalDeviceFeatures2</a>, <a href=\"#VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV\">VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV</a>, <a href=\"#VkPhysicalDeviceInlineUniformBlockFeaturesEXT\">VkPhysicalDeviceInlineUniformBlockFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceMeshShaderFeaturesNV\">VkPhysicalDeviceMeshShaderFeaturesNV</a>, <a href=\"#VkPhysicalDeviceMultiviewFeatures\">VkPhysicalDeviceMultiviewFeatures</a>, <a href=\"#VkPhysicalDeviceProtectedMemoryFeatures\">VkPhysicalDeviceProtectedMemoryFeatures</a>, <a href=\"#VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV\">VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV</a>, <a href=\"#VkPhysicalDeviceSamplerYcbcrConversionFeatures\">VkPhysicalDeviceSamplerYcbcrConversionFeatures</a>, <a href=\"#VkPhysicalDeviceShaderDrawParameterFeatures\">VkPhysicalDeviceShaderDrawParameterFeatures</a>, <a href=\"#VkPhysicalDeviceShaderImageFootprintFeaturesNV\">VkPhysicalDeviceShaderImageFootprintFeaturesNV</a>, <a href=\"#VkPhysicalDeviceShadingRateImageFeaturesNV\">VkPhysicalDeviceShadingRateImageFeaturesNV</a>, <a href=\"#VkPhysicalDeviceVariablePointerFeatures\">VkPhysicalDeviceVariablePointerFeatures</a>, <a href=\"#VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT\">VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT</a>, or <a href=\"#VkPhysicalDeviceVulkanMemoryModelFeaturesKHR\">VkPhysicalDeviceVulkanMemoryModelFeaturesKHR</a>"
+          "text": " Each <code>pNext</code> member of any structure (including this one) in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be either <code>NULL</code> or a pointer to a valid instance of <a href=\"#VkDeviceGroupDeviceCreateInfo\">VkDeviceGroupDeviceCreateInfo</a>, <a href=\"#VkPhysicalDevice16BitStorageFeatures\">VkPhysicalDevice16BitStorageFeatures</a>, <a href=\"#VkPhysicalDevice8BitStorageFeaturesKHR\">VkPhysicalDevice8BitStorageFeaturesKHR</a>, <a href=\"#VkPhysicalDeviceASTCDecodeFeaturesEXT\">VkPhysicalDeviceASTCDecodeFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT\">VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceComputeShaderDerivativesFeaturesNV\">VkPhysicalDeviceComputeShaderDerivativesFeaturesNV</a>, <a href=\"#VkPhysicalDeviceConditionalRenderingFeaturesEXT\">VkPhysicalDeviceConditionalRenderingFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceCornerSampledImageFeaturesNV\">VkPhysicalDeviceCornerSampledImageFeaturesNV</a>, <a href=\"#VkPhysicalDeviceDescriptorIndexingFeaturesEXT\">VkPhysicalDeviceDescriptorIndexingFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceExclusiveScissorFeaturesNV\">VkPhysicalDeviceExclusiveScissorFeaturesNV</a>, <a href=\"#VkPhysicalDeviceFeatures2\">VkPhysicalDeviceFeatures2</a>, <a href=\"#VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV\">VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV</a>, <a href=\"#VkPhysicalDeviceInlineUniformBlockFeaturesEXT\">VkPhysicalDeviceInlineUniformBlockFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceMeshShaderFeaturesNV\">VkPhysicalDeviceMeshShaderFeaturesNV</a>, <a href=\"#VkPhysicalDeviceMultiviewFeatures\">VkPhysicalDeviceMultiviewFeatures</a>, <a href=\"#VkPhysicalDeviceProtectedMemoryFeatures\">VkPhysicalDeviceProtectedMemoryFeatures</a>, <a href=\"#VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV\">VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV</a>, <a href=\"#VkPhysicalDeviceSamplerYcbcrConversionFeatures\">VkPhysicalDeviceSamplerYcbcrConversionFeatures</a>, <a href=\"#VkPhysicalDeviceShaderAtomicInt64FeaturesKHR\">VkPhysicalDeviceShaderAtomicInt64FeaturesKHR</a>, <a href=\"#VkPhysicalDeviceShaderDrawParameterFeatures\">VkPhysicalDeviceShaderDrawParameterFeatures</a>, <a href=\"#VkPhysicalDeviceShaderImageFootprintFeaturesNV\">VkPhysicalDeviceShaderImageFootprintFeaturesNV</a>, <a href=\"#VkPhysicalDeviceShadingRateImageFeaturesNV\">VkPhysicalDeviceShadingRateImageFeaturesNV</a>, <a href=\"#VkPhysicalDeviceVariablePointerFeatures\">VkPhysicalDeviceVariablePointerFeatures</a>, <a href=\"#VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT\">VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT</a>, or <a href=\"#VkPhysicalDeviceVulkanMemoryModelFeaturesKHR\">VkPhysicalDeviceVulkanMemoryModelFeaturesKHR</a>"
         },
         {
           "vuid": "VUID-VkDeviceCreateInfo-sType-unique",
@@ -2513,12 +2521,8 @@
           "text": " If the <a href=\"#features-features-tessellationShader\">tessellation shaders</a> feature is not enabled, <code>dstStageMask</code> <strong class=\"purple\">must</strong> not contain <code>VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT</code> or <code>VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT</code>"
         },
         {
-          "vuid": "VUID-vkCmdPipelineBarrier-pDependencies-02024",
-          "text": " If <code>vkCmdPipelineBarrier</code> is called within a render pass instance, the render pass <strong class=\"purple\">must</strong> have been created with at least one <code>VkSubpassDependency</code> instance in <code>VkRenderPassCreateInfo</code>::<code>pDependencies</code> that expresses a dependency from the current subpass to itself, and for which <code>srcStageMask</code> contains a subset of the bit values in <code>VkSubpassDependency</code>::<code>srcStageMask</code>, <code>dstStageMask</code> contains a subset of the bit values in <code>VkSubpassDependency</code>::<code>dstStageMask</code>, and <code>dependencyFlags</code> is equal to <code>VkSubpassDependency</code>::<code>dependencyFlags</code>."
-        },
-        {
-          "vuid": "VUID-vkCmdPipelineBarrier-pMemoryBarriers-02026",
-          "text": " If <code>vkCmdPipelineBarrier</code> is called within a render pass instance, for each element of <code>pMemoryBarriers</code> and <code>pImageMemoryBarriers</code>, the render pass <strong class=\"purple\">must</strong> have been defined with a <code>VkSubpassDependency</code> self-dependency for the current subpass with valid <code>srcStageMask</code>, <code>dstStageMask</code>, and <code>dependencyFlags</code> values such that <code>Vk*Barrier</code>::<code>srcAccessMask</code> contains a subset of the bit values in <code>VkSubpassDependency</code>::<code>srcAccessMask</code> and <code>Vk*Barrier</code>::<code>dstAccessMask</code> contains a subset of the bit values in <code>VkSubpassDependency</code>::<code>dstAccessMask</code>."
+          "vuid": "VUID-vkCmdPipelineBarrier-pDependencies-02285",
+          "text": " If <code>vkCmdPipelineBarrier</code> is called within a render pass instance, the render pass <strong class=\"purple\">must</strong> have been created with at least one <code>VkSubpassDependency</code> instance in <code>VkRenderPassCreateInfo</code>::<code>pDependencies</code> that expresses a dependency from the current subpass to itself, and for which <code>srcStageMask</code> contains a subset of the bit values in <code>VkSubpassDependency</code>::<code>srcStageMask</code>, <code>dstStageMask</code> contains a subset of the bit values in <code>VkSubpassDependency</code>::<code>dstStageMask</code>, <code>dependencyFlags</code> is equal to <code>VkSubpassDependency</code>::<code>dependencyFlags</code>, <code>srcAccessMask</code> member of each each element of <code>pMemoryBarriers</code> and <code>pImageMemoryBarriers</code> contains a subset of the bit values in <code>VkSubpassDependency</code>::<code>srcAccessMask</code>, and <code>dstAccessMask</code> member of each element of <code>pMemoryBarriers</code> and <code>pImageMemoryBarriers</code> contains a subset of the bit values in <code>VkSubpassDependency</code>::<code>dstAccessMask</code>"
         },
         {
           "vuid": "VUID-vkCmdPipelineBarrier-bufferMemoryBarrierCount-01178",
@@ -2955,8 +2959,8 @@
           "text": " Each <code>sType</code> member in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be unique"
         },
         {
-          "vuid": "VUID-VkRenderPassCreateInfo-flags-zerobitmask",
-          "text": " <code>flags</code> <strong class=\"purple\">must</strong> be <code>0</code>"
+          "vuid": "VUID-VkRenderPassCreateInfo-flags-parameter",
+          "text": " <code>flags</code> <strong class=\"purple\">must</strong> be a valid combination of <a href=\"#VkRenderPassCreateFlagBits\">VkRenderPassCreateFlagBits</a> values"
         },
         {
           "vuid": "VUID-VkRenderPassCreateInfo-pAttachments-parameter",
@@ -3109,6 +3113,12 @@
         {
           "vuid": "VUID-VkInputAttachmentAspectReference-aspectMask-requiredbitmask",
           "text": " <code>aspectMask</code> <strong class=\"purple\">must</strong> not be <code>0</code>"
+        }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_maintenance2)+(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkInputAttachmentAspectReferenceKHR-aspectMask-02250",
+          "text": " <code>aspectMask</code> <strong class=\"purple\">must</strong> not include <code>VK_IMAGE_ASPECT_MEMORY_PLANE</code><em>_i</em>_BIT_EXT for any index <em>i</em>."
         }
       ]
     },
@@ -3417,8 +3427,8 @@
           "text": " <code>pNext</code> <strong class=\"purple\">must</strong> be <code>NULL</code>"
         },
         {
-          "vuid": "VUID-VkRenderPassCreateInfo2KHR-flags-zerobitmask",
-          "text": " <code>flags</code> <strong class=\"purple\">must</strong> be <code>0</code>"
+          "vuid": "VUID-VkRenderPassCreateInfo2KHR-flags-parameter",
+          "text": " <code>flags</code> <strong class=\"purple\">must</strong> be a valid combination of <a href=\"#VkRenderPassCreateFlagBits\">VkRenderPassCreateFlagBits</a> values"
         },
         {
           "vuid": "VUID-VkRenderPassCreateInfo2KHR-pAttachments-parameter",
@@ -5190,11 +5200,7 @@
         },
         {
           "vuid": "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-parameter",
-          "text": " <code>pDynamicStates</code> <strong class=\"purple\">must</strong> be a valid pointer to an array of <code>dynamicStateCount</code> valid <a href=\"#VkDynamicState\">VkDynamicState</a> values"
-        },
-        {
-          "vuid": "VUID-VkPipelineDynamicStateCreateInfo-dynamicStateCount-arraylength",
-          "text": " <code>dynamicStateCount</code> <strong class=\"purple\">must</strong> be greater than <code>0</code>"
+          "text": " If <code>dynamicStateCount</code> is not <code>0</code>, <code>pDynamicStates</code> <strong class=\"purple\">must</strong> be a valid pointer to an array of <code>dynamicStateCount</code> valid <a href=\"#VkDynamicState\">VkDynamicState</a> values"
         }
       ]
     },
@@ -6933,39 +6939,11 @@
       ]
     },
     "VkImageCreateInfo": {
-      "!(VK_ANDROID_external_memory_android_hardware_buffer)": [
-        {
-          "vuid": "VUID-VkImageCreateInfo-format-00940",
-          "text": " The combination of <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> <strong class=\"purple\">must</strong> be supported, as indicated by a <code>VK_SUCCESS</code> return value from <code>vkGetPhysicalDeviceImageFormatProperties</code> invoked with the same values passed to the corresponding parameters."
-        },
-        {
-          "vuid": "VUID-VkImageCreateInfo-format-00943",
-          "text": " <code>format</code> <strong class=\"purple\">must</strong> not be <code>VK_FORMAT_UNDEFINED</code>"
-        }
-      ],
-      "(VK_ANDROID_external_memory_android_hardware_buffer)": [
-        {
-          "vuid": "VUID-VkImageCreateInfo-pNext-01889",
-          "text": " If the <code>pNext</code> chain does not contain an instance of <a href=\"#VkExternalFormatANDROID\">VkExternalFormatANDROID</a>, or if <code>format</code> is not <code>VK_FORMAT_UNDEFINED</code>, the combination of <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> <strong class=\"purple\">must</strong> be supported, as indicated by a <code>VK_SUCCESS</code> return value from <code>vkGetPhysicalDeviceImageFormatProperties</code> invoked with the same values passed to the corresponding parameters."
-        },
-        {
-          "vuid": "VUID-VkImageCreateInfo-pNext-01974",
-          "text": " If the <code>pNext</code> chain contains an instance of <a href=\"#VkExternalFormatANDROID\">VkExternalFormatANDROID</a>, and its member <code>externalFormat</code> is non-zero the <code>format</code> <strong class=\"purple\">must</strong> be <code>VK_FORMAT_UNDEFINED</code>."
-        },
-        {
-          "vuid": "VUID-VkImageCreateInfo-pNext-01975",
-          "text": " If the <code>pNext</code> chain does not contain an instance of <a href=\"#VkExternalFormatANDROID\">VkExternalFormatANDROID</a>, or does and its member <code>externalFormat</code> is <code>0</code> the <code>format</code> <strong class=\"purple\">must</strong> not be <code>VK_FORMAT_UNDEFINED</code>."
-        },
-        {
-          "vuid": "VUID-VkImageCreateInfo-pNext-01892",
-          "text": " If the <code>pNext</code> chain includes a <a href=\"#VkExternalMemoryImageCreateInfo\">VkExternalMemoryImageCreateInfo</a> structure whose <code>handleTypes</code> member includes <code>VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID</code>:"
-        },
-        {
-          "vuid": "VUID-VkImageCreateInfo-pNext-01893",
-          "text": " If the <code>pNext</code> chain includes a <a href=\"#VkExternalFormatANDROID\">VkExternalFormatANDROID</a> structure whose <code>externalFormat</code> member is not <code>0</code>:"
-        }
-      ],
       "core": [
+        {
+          "vuid": "VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251",
+          "text": " Each of the following values (as described in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>) <strong class=\"purple\">must</strong> not be undefined <code>imageCreateMaxMipLevels</code>, <code>imageCreateMaxArrayLayers</code>, <code>imageCreateMaxExtent</code>, and <code>imageCreateSampleCounts</code>."
+        },
         {
           "vuid": "VUID-VkImageCreateInfo-sharingMode-00941",
           "text": " If <code>sharingMode</code> is <code>VK_SHARING_MODE_CONCURRENT</code>, <code>pQueueFamilyIndices</code> <strong class=\"purple\">must</strong> be a valid pointer to an array of <code>queueFamilyIndexCount</code> <code>uint32_t</code> values"
@@ -6999,24 +6977,20 @@
           "text": " If <code>flags</code> contains <code>VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT</code>, <code>imageType</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TYPE_2D</code>"
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-imageType-00951",
-          "text": " If <code>imageType</code> is <code>VK_IMAGE_TYPE_1D</code>, <code>extent.width</code> <strong class=\"purple\">must</strong> be less than or equal to <code>VkPhysicalDeviceLimits</code>::<code>maxImageDimension1D</code>, or <code>VkImageFormatProperties</code>::<code>maxExtent.width</code> (as returned by <code>vkGetPhysicalDeviceImageFormatProperties</code> with <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> equal to those in this structure) - whichever is higher"
+          "vuid": "VUID-VkImageCreateInfo-extent-02252",
+          "text": " <code>extent.width</code> <strong class=\"purple\">must</strong> be less than or equal to <code>imageCreateMaxExtent.pname</code>:width (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>)."
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-imageType-00952",
-          "text": " If <code>imageType</code> is <code>VK_IMAGE_TYPE_2D</code> and <code>flags</code> does not contain <code>VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT</code>, <code>extent.width</code> and <code>extent.height</code> <strong class=\"purple\">must</strong> be less than or equal to <code>VkPhysicalDeviceLimits</code>::<code>maxImageDimension2D</code>, or <code>VkImageFormatProperties</code>::<code>maxExtent.width</code>/<code>height</code> (as returned by <code>vkGetPhysicalDeviceImageFormatProperties</code> with <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> equal to those in this structure) - whichever is higher"
+          "vuid": "VUID-VkImageCreateInfo-extent-02253",
+          "text": " <code>extent.height</code> <strong class=\"purple\">must</strong> be less than or equal to <code>imageCreateMaxExtent.pname</code>:height (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>)."
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-imageType-00953",
-          "text": " If <code>imageType</code> is <code>VK_IMAGE_TYPE_2D</code> and <code>flags</code> contains <code>VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT</code>, <code>extent.width</code> and <code>extent.height</code> <strong class=\"purple\">must</strong> be less than or equal to <code>VkPhysicalDeviceLimits</code>::<code>maxImageDimensionCube</code>, or <code>VkImageFormatProperties</code>::<code>maxExtent.width</code>/<code>height</code> (as returned by <code>vkGetPhysicalDeviceImageFormatProperties</code> with <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> equal to those in this structure) - whichever is higher"
+          "vuid": "VUID-VkImageCreateInfo-extent-02254",
+          "text": " <code>extent.depth</code> <strong class=\"purple\">must</strong> be less than or equal to <code>imageCreateMaxExtent.pname</code>:depth (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>)."
         },
         {
           "vuid": "VUID-VkImageCreateInfo-imageType-00954",
           "text": " If <code>imageType</code> is <code>VK_IMAGE_TYPE_2D</code> and <code>flags</code> contains <code>VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT</code>, <code>extent.width</code> and <code>extent.height</code> <strong class=\"purple\">must</strong> be equal and <code>arrayLayers</code> <strong class=\"purple\">must</strong> be greater than or equal to 6"
-        },
-        {
-          "vuid": "VUID-VkImageCreateInfo-imageType-00955",
-          "text": " If <code>imageType</code> is <code>VK_IMAGE_TYPE_3D</code>, <code>extent.width</code>, <code>extent.height</code> and <code>extent.depth</code> <strong class=\"purple\">must</strong> be less than or equal to <code>VkPhysicalDeviceLimits</code>::<code>maxImageDimension3D</code>, or <code>VkImageFormatProperties</code>::<code>maxExtent.width</code>/<code>height</code>/<code>depth</code> (as returned by <code>vkGetPhysicalDeviceImageFormatProperties</code> with <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> equal to those in this structure) - whichever is higher"
         },
         {
           "vuid": "VUID-VkImageCreateInfo-imageType-00956",
@@ -7031,20 +7005,20 @@
           "text": " <code>mipLevels</code> <strong class=\"purple\">must</strong> be less than or equal to the number of levels in the complete mipmap chain based on <span class=\"eq\"><code>extent.width</code></span>, <span class=\"eq\"><code>extent.height</code></span>, and <span class=\"eq\"><code>extent.depth</code></span>."
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-extent-00959",
-          "text": " <code>mipLevels</code> <strong class=\"purple\">must</strong> be less than or equal to <code>VkImageFormatProperties</code>::<code>maxMipLevels</code> (as returned by <code>vkGetPhysicalDeviceImageFormatProperties</code> with <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> equal to those in this structure)"
+          "vuid": "VUID-VkImageCreateInfo-mipLevels-02255",
+          "text": " <code>mipLevels</code> <strong class=\"purple\">must</strong> be less than or equal to <code>imageCreateMaxMipLevels</code> (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>)."
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-arrayLayers-00960",
-          "text": " <code>arrayLayers</code> <strong class=\"purple\">must</strong> be less than or equal to <code>VkImageFormatProperties</code>::<code>maxArrayLayers</code> (as returned by <code>vkGetPhysicalDeviceImageFormatProperties</code> with <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> equal to those in this structure)"
+          "vuid": "VUID-VkImageCreateInfo-arrayLayers-02256",
+          "text": " <code>arrayLayers</code> <strong class=\"purple\">must</strong> be less than or equal to <code>imageCreateMaxArrayLayers</code> (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>)."
         },
         {
           "vuid": "VUID-VkImageCreateInfo-imageType-00961",
           "text": " If <code>imageType</code> is <code>VK_IMAGE_TYPE_3D</code>, <code>arrayLayers</code> <strong class=\"purple\">must</strong> be <code>1</code>."
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-samples-00962",
-          "text": " If <code>samples</code> is not <code>VK_SAMPLE_COUNT_1_BIT</code>, <code>imageType</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TYPE_2D</code>, <code>flags</code> <strong class=\"purple\">must</strong> not contain <code>VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT</code>, <code>tiling</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TILING_OPTIMAL</code>, and <code>mipLevels</code> <strong class=\"purple\">must</strong> be equal to <code>1</code>"
+          "vuid": "VUID-VkImageCreateInfo-samples-02257",
+          "text": " If <code>samples</code> is not <code>VK_SAMPLE_COUNT_1_BIT</code>, then <code>imageType</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TYPE_2D</code>, <code>flags</code> <strong class=\"purple\">must</strong> not contain <code>VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT</code>, <code>mipLevels</code> <strong class=\"purple\">must</strong> be equal to <code>1</code>, and <code>imageCreateMaybeLinear</code> (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>) <strong class=\"purple\">must</strong> be <code>false</code>,"
         },
         {
           "vuid": "VUID-VkImageCreateInfo-usage-00963",
@@ -7063,8 +7037,8 @@
           "text": " If <code>usage</code> includes <code>VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT</code>, <code>usage</code> <strong class=\"purple\">must</strong> also contain at least one of <code>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</code>, <code>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</code>, or <code>VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT</code>."
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-samples-00967",
-          "text": " <code>samples</code> <strong class=\"purple\">must</strong> be a bit value that is set in <code>VkImageFormatProperties</code>::<code>sampleCounts</code> returned by <code>vkGetPhysicalDeviceImageFormatProperties</code> with <code>format</code>, <code>imageType</code>, <code>tiling</code>, <code>usage</code>, and <code>flags</code> equal to those in this structure"
+          "vuid": "VUID-VkImageCreateInfo-samples-02258",
+          "text": " <code>samples</code> <strong class=\"purple\">must</strong> be a bit value that is set in <code>imageCreateSampleCounts</code> (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>)."
         },
         {
           "vuid": "VUID-VkImageCreateInfo-usage-00968",
@@ -7179,6 +7153,30 @@
           "text": " If <code>sharingMode</code> is <code>VK_SHARING_MODE_CONCURRENT</code>, each element of <code>pQueueFamilyIndices</code> <strong class=\"purple\">must</strong> be unique and <strong class=\"purple\">must</strong> be less than <code>pQueueFamilyPropertyCount</code> returned by either <a href=\"#vkGetPhysicalDeviceQueueFamilyProperties\">vkGetPhysicalDeviceQueueFamilyProperties</a> or <a href=\"#vkGetPhysicalDeviceQueueFamilyProperties2\">vkGetPhysicalDeviceQueueFamilyProperties2</a> for the <code>physicalDevice</code> that was used to create <code>device</code>"
         }
       ],
+      "!(VK_ANDROID_external_memory_android_hardware_buffer)": [
+        {
+          "vuid": "VUID-VkImageCreateInfo-format-00943",
+          "text": " <code>format</code> <strong class=\"purple\">must</strong> not be <code>VK_FORMAT_UNDEFINED</code>"
+        }
+      ],
+      "(VK_ANDROID_external_memory_android_hardware_buffer)": [
+        {
+          "vuid": "VUID-VkImageCreateInfo-pNext-01974",
+          "text": " If the <code>pNext</code> chain contains an instance of <a href=\"#VkExternalFormatANDROID\">VkExternalFormatANDROID</a>, and its member <code>externalFormat</code> is non-zero the <code>format</code> <strong class=\"purple\">must</strong> be <code>VK_FORMAT_UNDEFINED</code>."
+        },
+        {
+          "vuid": "VUID-VkImageCreateInfo-pNext-01975",
+          "text": " If the <code>pNext</code> chain does not contain an instance of <a href=\"#VkExternalFormatANDROID\">VkExternalFormatANDROID</a>, or does and its member <code>externalFormat</code> is <code>0</code> the <code>format</code> <strong class=\"purple\">must</strong> not be <code>VK_FORMAT_UNDEFINED</code>."
+        },
+        {
+          "vuid": "VUID-VkImageCreateInfo-pNext-01892",
+          "text": " If the <code>pNext</code> chain includes a <a href=\"#VkExternalMemoryImageCreateInfo\">VkExternalMemoryImageCreateInfo</a> structure whose <code>handleTypes</code> member includes <code>VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID</code>:"
+        },
+        {
+          "vuid": "VUID-VkImageCreateInfo-pNext-01893",
+          "text": " If the <code>pNext</code> chain includes a <a href=\"#VkExternalFormatANDROID\">VkExternalFormatANDROID</a> structure whose <code>externalFormat</code> member is not <code>0</code>:"
+        }
+      ],
       "(VK_VERSION_1_1,VK_KHR_maintenance1)": [
         {
           "vuid": "VUID-VkImageCreateInfo-flags-00950",
@@ -7219,8 +7217,8 @@
           "text": " If the logical device was created with <a href=\"#VkDeviceGroupDeviceCreateInfo\">VkDeviceGroupDeviceCreateInfo</a>::<code>physicalDeviceCount</code> equal to 1, <code>flags</code> <strong class=\"purple\">must</strong> not contain <code>VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT</code>"
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-flags-00992",
-          "text": " If <code>flags</code> contains <code>VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT</code>, then <code>mipLevels</code> <strong class=\"purple\">must</strong> be one, <code>arrayLayers</code> <strong class=\"purple\">must</strong> be one, <code>imageType</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TYPE_2D</code>, and <code>tiling</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TILING_OPTIMAL</code>"
+          "vuid": "VUID-VkImageCreateInfo-flags-02259",
+          "text": " If <code>flags</code> contains <code>VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT</code>, then <code>mipLevels</code> <strong class=\"purple\">must</strong> be one, <code>arrayLayers</code> <strong class=\"purple\">must</strong> be one, <code>imageType</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TYPE_2D</code>. and <code>imageCreateMaybeLinear</code> (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>) <strong class=\"purple\">must</strong> be <code>false</code>."
         }
       ],
       "(VK_VERSION_1_1,VK_KHR_maintenance2)": [
@@ -7245,16 +7243,22 @@
           "text": " If the image <code>format</code> is one of those listed in <a href=\"#features-formats-requiring-sampler-ycbcr-conversion\">Formats requiring sampler Y&#8217;C<sub>B</sub>C<sub>R</sub> conversion for <code>VK_IMAGE_ASPECT_COLOR_BIT</code> image views</a>:"
         },
         {
-          "vuid": "VUID-VkImageCreateInfo-tiling-01575",
-          "text": " If <code>tiling</code> is <code>VK_IMAGE_TILING_OPTIMAL</code>, <code>format</code> is a <em>multi-planar</em> format, and <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> (as returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>) does not include <code>VK_FORMAT_FEATURE_DISJOINT_BIT</code>, <code>flags</code> <strong class=\"purple\">must</strong> not contain <code>VK_IMAGE_CREATE_DISJOINT_BIT</code>"
-        },
-        {
-          "vuid": "VUID-VkImageCreateInfo-tiling-01576",
-          "text": " If <code>tiling</code> is <code>VK_IMAGE_TILING_LINEAR</code>, <code>format</code> is a <em>multi-planar</em> format, and <code>VkFormatProperties</code>::<code>linearTilingFeatures</code> (as returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>) does not include <code>VK_FORMAT_FEATURE_DISJOINT_BIT</code>, <code>flags</code> <strong class=\"purple\">must</strong> not contain <code>VK_IMAGE_CREATE_DISJOINT_BIT</code>"
+          "vuid": "VUID-VkImageCreateInfo-imageCreateFormatFeatures-02260",
+          "text": " If pame:format is a <em>multi-planar</em> format, and if <code>imageCreateFormatFeatures</code> (as defined in <a href=\"#resources-image-creation-limits\">Image Creation Limits</a>) does not contain <code>VK_FORMAT_FEATURE_DISJOINT_BIT</code>, then <code>flags</code> <strong class=\"purple\">must</strong> not contain <code>VK_IMAGE_CREATE_DISJOINT_BIT</code>."
         },
         {
           "vuid": "VUID-VkImageCreateInfo-format-01577",
           "text": " If <code>format</code> is not a <em>multi-planar</em> format, and <code>flags</code> does not include <code>VK_IMAGE_CREATE_ALIAS_BIT</code>, <code>flags</code> <strong class=\"purple\">must</strong> not contain <code>VK_IMAGE_CREATE_DISJOINT_BIT</code>"
+        }
+      ],
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkImageCreateInfo-tiling-02261",
+          "text": " If <code>tiling</code> is <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>, then the <code>pNext</code> chain <strong class=\"purple\">must</strong> contain exactly one of <a href=\"#VkImageDrmFormatModifierListCreateInfoEXT\">VkImageDrmFormatModifierListCreateInfoEXT</a> or <a href=\"#VkImageDrmFormatModifierExplicitCreateInfoEXT\">VkImageDrmFormatModifierExplicitCreateInfoEXT</a>."
+        },
+        {
+          "vuid": "VUID-VkImageCreateInfo-pNext-02262",
+          "text": " If the <code>pNext</code> chain contains <a href=\"#VkImageDrmFormatModifierListCreateInfoEXT\">VkImageDrmFormatModifierListCreateInfoEXT</a> or <a href=\"#VkImageDrmFormatModifierExplicitCreateInfoEXT\">VkImageDrmFormatModifierExplicitCreateInfoEXT</a>, then <code>tiling</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>."
         }
       ],
       "(VK_EXT_sample_locations)": [
@@ -7388,12 +7392,48 @@
         }
       ]
     },
+    "VkImageDrmFormatModifierListCreateInfoEXT": {
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkImageDrmFormatModifierListCreateInfoEXT-pDrmFormatModifiers-02263",
+          "text": " Each <em>modifier</em> in <code>pDrmFormatModifiers</code> must be compatible with the parameters in <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> and its <code>pNext</code> chain, as determined by querying <a href=\"#VkPhysicalDeviceImageFormatInfo2\">VkPhysicalDeviceImageFormatInfo2</a> extended with <a href=\"#VkPhysicalDeviceImageDrmFormatModifierInfoEXT\">VkPhysicalDeviceImageDrmFormatModifierInfoEXT</a>."
+        }
+      ]
+    },
+    "VkImageDrmFormatModifierExplicitCreateInfoEXT": {
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-drmFormatModifier-02264",
+          "text": " <code>drmFormatModifier</code> must be compatible with the parameters in <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> and its <code>pNext</code> chain, as determined by querying <a href=\"#VkPhysicalDeviceImageFormatInfo2KHR\">VkPhysicalDeviceImageFormatInfo2KHR</a> extended with <a href=\"#VkPhysicalDeviceImageDrmFormatModifierInfoEXT\">VkPhysicalDeviceImageDrmFormatModifierInfoEXT</a>."
+        },
+        {
+          "vuid": "VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-drmFormatModifierPlaneCount-02265",
+          "text": " <code>drmFormatModifierPlaneCount</code> <strong class=\"purple\">must</strong> be equal to the <a href=\"#VkDrmFormatModifierPropertiesEXT\">VkDrmFormatModifierPropertiesEXT</a>::<code>drmFormatModifierPlaneCount</code> associated with <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a>::<code>format</code> and <code>drmFormatModifier</code>, as found by querying <a href=\"#VkDrmFormatModifierPropertiesListEXT\">VkDrmFormatModifierPropertiesListEXT</a>."
+        },
+        {
+          "vuid": "VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-pPlaneLayouts-02266",
+          "text": " For each element of <code>pPlaneLayouts</code>:"
+        }
+      ]
+    },
     "vkGetImageSubresourceLayout": {
-      "core": [
+      "!(VK_EXT_image_drm_format_modifier)": [
         {
           "vuid": "VUID-vkGetImageSubresourceLayout-image-00996",
           "text": " <code>image</code> <strong class=\"purple\">must</strong> have been created with <code>tiling</code> equal to <code>VK_IMAGE_TILING_LINEAR</code>"
+        }
+      ],
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-vkGetImageSubresourceLayout-image-02270",
+          "text": " <code>image</code> <strong class=\"purple\">must</strong> have been created with <code>tiling</code> equal to <code>VK_IMAGE_TILING_LINEAR</code> or <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>"
         },
+        {
+          "vuid": "VUID-vkGetImageSubresourceLayout-tiling-02271",
+          "text": "  If the <code>tiling</code> of the <code>image</code> is  <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>, then the <code>aspectMask</code>  member of <code>pSubresource</code> <strong class=\"purple\">must</strong> be  <code>VK_IMAGE_ASPECT_MEMORY_PLANE</code><em>_i</em>_BIT_EXT and the index <em>i</em>  <strong class=\"purple\">must</strong> be less than the  <a href=\"#VkDrmFormatModifierPropertiesEXT\"><code>drmFormatModifierPlaneCount</code></a>  associated with the image&#8217;s <a href=\"#VkImageCreateInfo\"><code>format</code></a> and <a href=\"#VkImageDrmFormatModifierPropertiesEXT\"><code>drmFormatModifier</code></a>."
+        }
+      ],
+      "core": [
         {
           "vuid": "VUID-vkGetImageSubresourceLayout-aspectMask-00997",
           "text": " The <code>aspectMask</code> member of <code>pSubresource</code> <strong class=\"purple\">must</strong> only have a single bit set"
@@ -7430,11 +7470,11 @@
       "(VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion)": [
         {
           "vuid": "VUID-vkGetImageSubresourceLayout-format-01581",
-          "text": " If the <code>format</code> of <code>image</code> is a <a href=\"#features-formats-requiring-sampler-ycbcr-conversion\">multi-planar format</a> with two planes, the <code>aspectMask</code> member of <code>pSubresource</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code>"
+          "text": " If the <code>tiling</code> of the <code>image</code> is <code>VK_IMAGE_TILING_LINEAR</code> and its <code>format</code> is a <a href=\"#features-formats-requiring-sampler-ycbcr-conversion\">multi-planar format</a> with two planes, the <code>aspectMask</code> member of <code>pSubresource</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code>"
         },
         {
           "vuid": "VUID-vkGetImageSubresourceLayout-format-01582",
-          "text": " If the <code>format</code> of <code>image</code> is a <a href=\"#features-formats-requiring-sampler-ycbcr-conversion\">multi-planar format</a> with three planes, the <code>aspectMask</code> member of <code>pSubresource</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code>, <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_2_BIT</code>"
+          "text": " If the <code>tiling</code> of the <code>image</code> is <code>VK_IMAGE_TILING_LINEAR</code> and its <code>format</code> is a <a href=\"#features-formats-requiring-sampler-ycbcr-conversion\">multi-planar format</a> with three planes, the <code>aspectMask</code> member of <code>pSubresource</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code>, <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_2_BIT</code>"
         }
       ],
       "(VK_ANDROID_external_memory_android_hardware_buffer)": [
@@ -7453,6 +7493,14 @@
         {
           "vuid": "VUID-VkImageSubresource-aspectMask-requiredbitmask",
           "text": " <code>aspectMask</code> <strong class=\"purple\">must</strong> not be <code>0</code>"
+        }
+      ]
+    },
+    "vkGetImageDrmFormatModifierPropertiesEXT": {
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-vkGetImageDrmFormatModifierPropertiesEXT-image-02272",
+          "text": " <code>image</code> <strong class=\"purple\">must</strong> have been created with <a href=\"#VkImageCreateInfo\"><code>tiling</code></a> equal to <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>."
         }
       ]
     },
@@ -7519,24 +7567,24 @@
           "text": " If the <a href=\"#features-features-imageCubeArray\">image cubemap arrays</a> feature is not enabled, <code>viewType</code> <strong class=\"purple\">must</strong> not be <code>VK_IMAGE_VIEW_TYPE_CUBE_ARRAY</code>"
         },
         {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01006",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_LINEAR</code>, <code>format</code> <strong class=\"purple\">must</strong> be format that has at least one supported feature bit present in the value of <code>VkFormatProperties</code>::<code>linearTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
+          "vuid": "VUID-VkImageViewCreateInfo-None-02273",
+          "text": " The <a href=\"#resources-image-view-format-features\">format features</a> of the resultant image view <strong class=\"purple\">must</strong> contain at least one bit."
         },
         {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01008",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_LINEAR</code> and <code>usage</code> contains <code>VK_IMAGE_USAGE_SAMPLED_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for sampled images, as specified by the <code>VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT</code> flag in <code>VkFormatProperties</code>::<code>linearTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
+          "vuid": "VUID-VkImageViewCreateInfo-usage-02274",
+          "text": " If <code>usage</code> contains <code>VK_IMAGE_USAGE_SAMPLED_BIT</code>, then the <a href=\"#resources-image-view-format-features\">format features</a> of the resultant image view <strong class=\"purple\">must</strong> contain <code>VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT</code>."
         },
         {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01009",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_LINEAR</code> and <code>usage</code> contains <code>VK_IMAGE_USAGE_STORAGE_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for storage images, as specified by the <code>VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT</code> flag in <code>VkFormatProperties</code>::<code>linearTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
+          "vuid": "VUID-VkImageViewCreateInfo-usage-02275",
+          "text": " If <code>usage</code> contains <code>VK_IMAGE_USAGE_STORAGE_BIT</code>, then the image view&#8217;s <a href=\"#resources-image-view-format-features\">format features</a> <strong class=\"purple\">must</strong> contain <code>VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT</code>."
         },
         {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01010",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_LINEAR</code> and <code>usage</code> contains <code>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for color attachments, as specified by the <code>VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT</code> flag in <code>VkFormatProperties</code>::<code>linearTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
+          "vuid": "VUID-VkImageViewCreateInfo-usage-02276",
+          "text": " If <code>usage</code> contains <code>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</code>, then the image view&#8217;s <a href=\"#resources-image-view-format-features\">format features</a> <strong class=\"purple\">must</strong> contain <code>VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT</code>."
         },
         {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01011",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_LINEAR</code> and <code>usage</code> contains <code>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for depth/stencil attachments, as specified by the <code>VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT</code> flag in <code>VkFormatProperties</code>::<code>linearTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
+          "vuid": "VUID-VkImageViewCreateInfo-usage-02277",
+          "text": " If <code>usage</code> contains <code>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</code>, then the image view&#8217;s <a href=\"#resources-image-view-format-features\">format features</a> <strong class=\"purple\">must</strong> contain <code>VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT</code>."
         },
         {
           "vuid": "VUID-VkImageViewCreateInfo-subresourceRange-01478",
@@ -7637,54 +7685,6 @@
           "text": " If <code>image</code> was created with <code>usage</code> containing <code>VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV</code>, <code>format</code> <strong class=\"purple\">must</strong> be <code>VK_FORMAT_R8_UINT</code>"
         }
       ],
-      "!(VK_ANDROID_external_memory_android_hardware_buffer)": [
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01012",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code>, <code>format</code> <strong class=\"purple\">must</strong> be format that has at least one supported feature bit present in the value of <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01013",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code> and <code>usage</code> contains <code>VK_IMAGE_USAGE_SAMPLED_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for sampled images, as specified by the <code>VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT</code> flag in <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01014",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code> and <code>usage</code> contains <code>VK_IMAGE_USAGE_STORAGE_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for storage images, as specified by the <code>VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT</code> flag in <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01015",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code> and <code>usage</code> contains <code>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for color attachments, as specified by the <code>VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT</code> flag in <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01016",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code> and <code>usage</code> contains <code>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for depth/stencil attachments, as specified by the <code>VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT</code> flag in <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        }
-      ],
-      "(VK_ANDROID_external_memory_android_hardware_buffer)": [
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01965",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code> and <code>format</code> is not <code>VK_FORMAT_UNDEFINED</code>, <code>format</code> <strong class=\"purple\">must</strong> be format that has at least one supported feature bit present in the value of <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01966",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code>, and <code>format</code> is not <code>VK_FORMAT_UNDEFINED</code>, and <code>usage</code> contains <code>VK_IMAGE_USAGE_SAMPLED_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for sampled images, as specified by the <code>VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT</code> flag in <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01967",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code>, and <code>format</code> is not <code>VK_FORMAT_UNDEFINED</code>, and <code>usage</code> contains <code>VK_IMAGE_USAGE_STORAGE_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for storage images, as specified by the <code>VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT</code> flag in <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01968",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code>, and <code>format</code> is not <code>VK_FORMAT_UNDEFINED</code>, and <code>usage</code> contains <code>VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for color attachments, as specified by the <code>VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT</code> flag in <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01969",
-          "text": " If <code>image</code> was created with <code>VK_IMAGE_TILING_OPTIMAL</code>, and <code>format</code> is not <code>VK_FORMAT_UNDEFINED</code>, and <code>usage</code> contains <code>VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT</code>, <code>format</code> <strong class=\"purple\">must</strong> be supported for depth/stencil attachments, as specified by the <code>VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT</code> flag in <code>VkFormatProperties</code>::<code>optimalTilingFeatures</code> returned by <code>vkGetPhysicalDeviceFormatProperties</code> with the same value of <code>format</code>"
-        },
-        {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01896",
-          "text": " If <code>image</code> has an <a href=\"#memory-external-android-hardware-buffer-external-formats\">external format</a>:"
-        }
-      ],
       "!(VK_VERSION_1_1,VK_KHR_maintenance1)": [
         {
           "vuid": "VUID-VkImageViewCreateInfo-subresourceRange-01480",
@@ -7748,6 +7748,12 @@
           "vuid": "VUID-VkImageViewCreateInfo-image-01019",
           "text": " If <code>image</code> was not created with the <code>VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT</code> flag, <code>format</code> <strong class=\"purple\">must</strong> be identical to the <code>format</code> used to create <code>image</code>"
         }
+      ],
+      "(VK_ANDROID_external_memory_android_hardware_buffer)": [
+        {
+          "vuid": "VUID-VkImageViewCreateInfo-image-01896",
+          "text": " If <code>image</code> has an <a href=\"#memory-external-android-hardware-buffer-external-formats\">external format</a>:"
+        }
       ]
     },
     "VkImageViewUsageCreateInfo": {
@@ -7793,6 +7799,12 @@
         {
           "vuid": "VUID-VkImageSubresourceRange-aspectMask-01670",
           "text": " If <code>aspectMask</code> includes <code>VK_IMAGE_ASPECT_COLOR_BIT</code>, then it <strong class=\"purple\">must</strong> not include any of <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code>, <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code>, or <code>VK_IMAGE_ASPECT_PLANE_2_BIT</code>"
+        }
+      ],
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkImageSubresourceRange-aspectMask-02278",
+          "text": " <code>aspectMask</code> <strong class=\"purple\">must</strong> not include <code>VK_IMAGE_ASPECT_MEMORY_PLANE</code><em>_i</em>_BIT_EXT for any index <em>i</em>."
         }
       ]
     },
@@ -7979,7 +7991,19 @@
         {
           "vuid": "VUID-VkImageMemoryRequirementsInfo2-image-01590",
           "text": " If <code>image</code> was not created with the <code>VK_IMAGE_CREATE_DISJOINT_BIT</code> flag, there <strong class=\"purple\">must</strong> not be a <a href=\"#VkImagePlaneMemoryRequirementsInfo\">VkImagePlaneMemoryRequirementsInfo</a> in the <code>pNext</code> chain of the <a href=\"#VkImageMemoryRequirementsInfo2\">VkImageMemoryRequirementsInfo2</a> structure"
+        }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_get_memory_requirements2)+(VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion)+(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkImageMemoryRequirementsInfo2KHR-image-02279",
+          "text": " If <code>image</code> was created with <code>VK_IMAGE_CREATE_DISJOINT_BIT</code> and with <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>, then there <strong class=\"purple\">must</strong> be a <a href=\"#VkImagePlaneMemoryRequirementsInfo\">VkImagePlaneMemoryRequirementsInfo</a> in the <code>pNext</code> chain of the <a href=\"#VkImageMemoryRequirementsInfo2\">VkImageMemoryRequirementsInfo2</a> structure"
         },
+        {
+          "vuid": "VUID-VkImageMemoryRequirementsInfo2KHR-image-02280",
+          "text": " If <code>image</code> was created with a single-plane format and with any <code>tiling</code> other than <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>, then there <strong class=\"purple\">must</strong> not be a <a href=\"#VkImagePlaneMemoryRequirementsInfo\">VkImagePlaneMemoryRequirementsInfo</a> in the <code>pNext</code> chain of the <a href=\"#VkImageMemoryRequirementsInfo2\">VkImageMemoryRequirementsInfo2</a> structure"
+        }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_get_memory_requirements2)+(VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion)+!(VK_EXT_image_drm_format_modifier)": [
         {
           "vuid": "VUID-VkImageMemoryRequirementsInfo2-image-01591",
           "text": " If <code>image</code> was created with a single-plane format, there <strong class=\"purple\">must</strong> not be a <a href=\"#VkImagePlaneMemoryRequirementsInfo\">VkImagePlaneMemoryRequirementsInfo</a> in the <code>pNext</code> chain of the <a href=\"#VkImageMemoryRequirementsInfo2\">VkImageMemoryRequirementsInfo2</a> structure"
@@ -8009,8 +8033,8 @@
     "VkImagePlaneMemoryRequirementsInfo": {
       "(VK_VERSION_1_1,VK_KHR_get_memory_requirements2)+(VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion)": [
         {
-          "vuid": "VUID-VkImagePlaneMemoryRequirementsInfo-planeAspect-01592",
-          "text": " <code>planeAspect</code> <strong class=\"purple\">must</strong> be an aspect that exists in the format; that is, for a two-plane image <code>planeAspect</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code>, and for a three-plane image <code>planeAspect</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code>, <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_2_BIT</code>"
+          "vuid": "VUID-VkImagePlaneMemoryRequirementsInfoKHR-planeAspect-02281",
+          "text": " If the image&#8217;s tiling is <code>VK_IMAGE_TILING_LINEAR</code> or <code>VK_IMAGE_TILING_OPTIMAL</code>, then <code>planeAspect</code> <strong class=\"purple\">must</strong> be a single valid <em>format plane</em> for the image. (That is, for a two-plane image <code>planeAspect</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code>, and for a three-plane image <code>planeAspect</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code>, <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_2_BIT</code>)."
         },
         {
           "vuid": "VUID-VkImagePlaneMemoryRequirementsInfo-sType-sType",
@@ -8019,6 +8043,12 @@
         {
           "vuid": "VUID-VkImagePlaneMemoryRequirementsInfo-planeAspect-parameter",
           "text": " <code>planeAspect</code> <strong class=\"purple\">must</strong> be a valid <a href=\"#VkImageAspectFlagBits\">VkImageAspectFlagBits</a> value"
+        }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_get_memory_requirements2)+(VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion)+(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkImagePlaneMemoryRequirementsInfoKHR-planeAspect-02282",
+          "text": "  If the image&#8217;s tiling is <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>,  then <code>planeAspect</code> <strong class=\"purple\">must</strong> be a single valid <em>memory plane</em> for the  image.  (That is, <code>aspectMask</code> <strong class=\"purple\">must</strong> specify a plane index that is less than  the  <a href=\"#VkDrmFormatModifierPropertiesEXT\"><code>drmFormatModifierPlaneCount</code></a>  associated with the image&#8217;s <a href=\"#VkImageCreateInfo\"><code>format</code></a> and <a href=\"#VkImageDrmFormatModifierPropertiesEXT\"><code>drmFormatModifier</code></a>.)"
         }
       ]
     },
@@ -8547,8 +8577,8 @@
     "VkBindImagePlaneMemoryInfo": {
       "(VK_VERSION_1_1,VK_KHR_bind_memory2)+(VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion)": [
         {
-          "vuid": "VUID-VkBindImagePlaneMemoryInfo-planeAspect-01642",
-          "text": " <code>planeAspect</code> <strong class=\"purple\">must</strong> be a single valid plane aspect for the image format (that is, <code>planeAspect</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code> for &#8220;<code>_2PLANE</code>&#8221; formats and <code>planeAspect</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code>, <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code>, or <code>VK_IMAGE_ASPECT_PLANE_2_BIT</code> for &#8220;<code>_3PLANE</code>&#8221; formats)"
+          "vuid": "VUID-VkBindImagePlaneMemoryInfoKHR-planeAspect-02283",
+          "text": " If the image&#8217;s tiling is <code>VK_IMAGE_TILING_LINEAR</code> or <code>VK_IMAGE_TILING_OPTIMAL</code>, then <code>planeAspect</code> <strong class=\"purple\">must</strong> be a single valid <em>format plane</em> for the image. (That is, <code>planeAspect</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code> or <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code> for &#8220;<code>_2PLANE</code>&#8221; formats and <code>planeAspect</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_ASPECT_PLANE_0_BIT</code>, <code>VK_IMAGE_ASPECT_PLANE_1_BIT</code>, or <code>VK_IMAGE_ASPECT_PLANE_2_BIT</code> for &#8220;<code>_3PLANE</code>&#8221; formats.)"
         },
         {
           "vuid": "VUID-VkBindImagePlaneMemoryInfo-None-01643",
@@ -8561,6 +8591,12 @@
         {
           "vuid": "VUID-VkBindImagePlaneMemoryInfo-planeAspect-parameter",
           "text": " <code>planeAspect</code> <strong class=\"purple\">must</strong> be a valid <a href=\"#VkImageAspectFlagBits\">VkImageAspectFlagBits</a> value"
+        }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_bind_memory2)+(VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion)+(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkBindImagePlaneMemoryInfoKHR-planeAspect-02284",
+          "text": "  If the image&#8217;s tiling is <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>,  then <code>planeAspect</code> <strong class=\"purple\">must</strong> be a single valid <em>memory plane</em> for the  image.  (That is, <code>aspectMask</code> <strong class=\"purple\">must</strong> specify a plane index that is less than  the  <a href=\"#VkDrmFormatModifierPropertiesEXT\"><code>drmFormatModifierPlaneCount</code></a>  associated with the image&#8217;s <a href=\"#VkImageCreateInfo\"><code>format</code></a> and <a href=\"#VkImageDrmFormatModifierPropertiesEXT\"><code>drmFormatModifier</code></a>.)"
         }
       ]
     },
@@ -11409,6 +11445,12 @@
           "text": " <code>aspectMask</code> <strong class=\"purple\">must</strong> not be <code>0</code>"
         }
       ],
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkClearAttachment-aspectMask-02246",
+          "text": " <code>aspectMask</code> <strong class=\"purple\">must</strong> not include <code>VK_IMAGE_ASPECT_MEMORY_PLANE</code><em>_i</em>_BIT_EXT for any index <em>i</em>."
+        }
+      ],
       "(VK_VERSION_1_1)": [
         {
           "vuid": "VUID-VkClearAttachment-commandBuffer-01809",
@@ -12088,6 +12130,12 @@
           "vuid": "VUID-VkImageSubresourceLayers-aspectMask-requiredbitmask",
           "text": " <code>aspectMask</code> <strong class=\"purple\">must</strong> not be <code>0</code>"
         }
+      ],
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkImageSubresourceLayers-aspectMask-02247",
+          "text": " <code>aspectMask</code> <strong class=\"purple\">must</strong> not include <code>VK_IMAGE_ASPECT_MEMORY_PLANE</code><em>_i</em>_BIT_EXT for any index <em>i</em>."
+        }
       ]
     },
     "vkCmdCopyBufferToImage": {
@@ -12461,12 +12509,14 @@
           "text": " If the calling command&#8217;s <code>VkImage</code> parameter is of <a href=\"#VkImageType\">VkImageType</a> <code>VK_IMAGE_TYPE_3D</code>, the <code>baseArrayLayer</code> and <code>layerCount</code> members of <code>imageSubresource</code> <strong class=\"purple\">must</strong> be <code>0</code> and <code>1</code>, respectively"
         },
         {
-          "vuid": "VUID-VkBufferImageCopy-None-00214",
-          "text": " When copying to the depth aspect of an image subresource, the data in the source buffer <strong class=\"purple\">must</strong> be in the range <span class=\"eq\">[0,1]</span>"
-        },
-        {
           "vuid": "VUID-VkBufferImageCopy-imageSubresource-parameter",
           "text": " <code>imageSubresource</code> <strong class=\"purple\">must</strong> be a valid <code>VkImageSubresourceLayers</code> structure"
+        }
+      ],
+      "!(VK_EXT_depth_range_unrestricted)": [
+        {
+          "vuid": "VUID-VkBufferImageCopy-None-00214",
+          "text": " When copying to the depth aspect of an image subresource, the data in the source buffer <strong class=\"purple\">must</strong> be in the range <span class=\"eq\">[0,1]</span>"
         }
       ]
     },
@@ -15556,15 +15606,11 @@
         },
         {
           "vuid": "VUID-VkSampleLocationsInfoEXT-sampleLocationsPerPixel-parameter",
-          "text": " <code>sampleLocationsPerPixel</code> <strong class=\"purple\">must</strong> be a valid <a href=\"#VkSampleCountFlagBits\">VkSampleCountFlagBits</a> value"
+          "text": " If <code>sampleLocationsPerPixel</code> is not <code>0</code>, <code>sampleLocationsPerPixel</code> <strong class=\"purple\">must</strong> be a valid <a href=\"#VkSampleCountFlagBits\">VkSampleCountFlagBits</a> value"
         },
         {
           "vuid": "VUID-VkSampleLocationsInfoEXT-pSampleLocations-parameter",
-          "text": " <code>pSampleLocations</code> <strong class=\"purple\">must</strong> be a valid pointer to an array of <code>sampleLocationsCount</code> <code>VkSampleLocationEXT</code> structures"
-        },
-        {
-          "vuid": "VUID-VkSampleLocationsInfoEXT-sampleLocationsCount-arraylength",
-          "text": " <code>sampleLocationsCount</code> <strong class=\"purple\">must</strong> be greater than <code>0</code>"
+          "text": " If <code>sampleLocationsCount</code> is not <code>0</code>, <code>pSampleLocations</code> <strong class=\"purple\">must</strong> be a valid pointer to an array of <code>sampleLocationsCount</code> <code>VkSampleLocationEXT</code> structures"
         }
       ]
     },
@@ -18182,6 +18228,46 @@
         }
       ]
     },
+    "vkCreateImagePipeSurfaceFUCHSIA": {
+      "(VK_KHR_surface)+(VK_FUCHSIA_imagepipe_surface)": [
+        {
+          "vuid": "VUID-vkCreateImagePipeSurfaceFUCHSIA-instance-parameter",
+          "text": " <code>instance</code> <strong class=\"purple\">must</strong> be a valid <code>VkInstance</code> handle"
+        },
+        {
+          "vuid": "VUID-vkCreateImagePipeSurfaceFUCHSIA-pCreateInfo-parameter",
+          "text": " <code>pCreateInfo</code> <strong class=\"purple\">must</strong> be a valid pointer to a valid <code>VkImagePipeSurfaceCreateInfoFUCHSIA</code> structure"
+        },
+        {
+          "vuid": "VUID-vkCreateImagePipeSurfaceFUCHSIA-pAllocator-parameter",
+          "text": " If <code>pAllocator</code> is not <code>NULL</code>, <code>pAllocator</code> <strong class=\"purple\">must</strong> be a valid pointer to a valid <code>VkAllocationCallbacks</code> structure"
+        },
+        {
+          "vuid": "VUID-vkCreateImagePipeSurfaceFUCHSIA-pSurface-parameter",
+          "text": " <code>pSurface</code> <strong class=\"purple\">must</strong> be a valid pointer to a <code>VkSurfaceKHR</code> handle"
+        }
+      ]
+    },
+    "VkImagePipeSurfaceCreateInfoFUCHSIA": {
+      "(VK_KHR_surface)+(VK_FUCHSIA_imagepipe_surface)": [
+        {
+          "vuid": "VUID-VkImagePipeSurfaceCreateInfoFUCHSIA-imagePipeHandle-00000",
+          "text": " <code>imagePipeHandle</code> <strong class=\"purple\">must</strong> be a valid <code>zx_handle_t</code>"
+        },
+        {
+          "vuid": "VUID-VkImagePipeSurfaceCreateInfoFUCHSIA-sType-sType",
+          "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA</code>"
+        },
+        {
+          "vuid": "VUID-VkImagePipeSurfaceCreateInfoFUCHSIA-pNext-pNext",
+          "text": " <code>pNext</code> <strong class=\"purple\">must</strong> be <code>NULL</code>"
+        },
+        {
+          "vuid": "VUID-VkImagePipeSurfaceCreateInfoFUCHSIA-flags-zerobitmask",
+          "text": " <code>flags</code> <strong class=\"purple\">must</strong> be <code>0</code>"
+        }
+      ]
+    },
     "vkCreateIOSSurfaceMVK": {
       "(VK_KHR_surface)+(VK_MVK_ios_surface)": [
         {
@@ -19877,8 +19963,8 @@
     "vkCmdTraceRaysNVX": {
       "(VK_NVX_raytracing)": [
         {
-          "vuid": "VUID-vkCmdTraceRaysNVX-cmdBuf-parameter",
-          "text": " <code>cmdBuf</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
+          "vuid": "VUID-vkCmdTraceRaysNVX-commandBuffer-parameter",
+          "text": " <code>commandBuffer</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
         },
         {
           "vuid": "VUID-vkCmdTraceRaysNVX-raygenShaderBindingTableBuffer-parameter",
@@ -19902,7 +19988,7 @@
         },
         {
           "vuid": "VUID-vkCmdTraceRaysNVX-commonparent",
-          "text": " Each of <code>cmdBuf</code>, <code>hitShaderBindingTableBuffer</code>, <code>missShaderBindingTableBuffer</code>, and <code>raygenShaderBindingTableBuffer</code> <strong class=\"purple\">must</strong> have been created, allocated, or retrieved from the same <code>VkDevice</code>"
+          "text": " Each of <code>commandBuffer</code>, <code>hitShaderBindingTableBuffer</code>, <code>missShaderBindingTableBuffer</code>, and <code>raygenShaderBindingTableBuffer</code> <strong class=\"purple\">must</strong> have been created, allocated, or retrieved from the same <code>VkDevice</code>"
         }
       ]
     },
@@ -19913,8 +19999,8 @@
           "text": " <code>geometryCount</code> <strong class=\"purple\">must</strong> be less than or equal to <code>VkPhysicalDeviceRaytracingPropertiesNVX</code>::<code>maxGeometryCount</code>"
         },
         {
-          "vuid": "VUID-vkCmdBuildAccelerationStructureNVX-cmdBuf-parameter",
-          "text": " <code>cmdBuf</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
+          "vuid": "VUID-vkCmdBuildAccelerationStructureNVX-commandBuffer-parameter",
+          "text": " <code>commandBuffer</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
         },
         {
           "vuid": "VUID-vkCmdBuildAccelerationStructureNVX-type-parameter",
@@ -19954,7 +20040,7 @@
         },
         {
           "vuid": "VUID-vkCmdBuildAccelerationStructureNVX-commonparent",
-          "text": " Each of <code>cmdBuf</code>, <code>dst</code>, <code>instanceData</code>, <code>scratch</code>, and <code>src</code> that are valid handles <strong class=\"purple\">must</strong> have been created, allocated, or retrieved from the same <code>VkDevice</code>"
+          "text": " Each of <code>commandBuffer</code>, <code>dst</code>, <code>instanceData</code>, <code>scratch</code>, and <code>src</code> that are valid handles <strong class=\"purple\">must</strong> have been created, allocated, or retrieved from the same <code>VkDevice</code>"
         }
       ]
     },
@@ -19965,8 +20051,8 @@
           "text": " <code>queryType</code> <strong class=\"purple\">must</strong> be VK_QUERY_TYPE_COMPACTED_SIZE_NVX"
         },
         {
-          "vuid": "VUID-vkCmdWriteAccelerationStructurePropertiesNVX-cmdBuf-parameter",
-          "text": " <code>cmdBuf</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
+          "vuid": "VUID-vkCmdWriteAccelerationStructurePropertiesNVX-commandBuffer-parameter",
+          "text": " <code>commandBuffer</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
         },
         {
           "vuid": "VUID-vkCmdWriteAccelerationStructurePropertiesNVX-accelerationStructure-parameter",
@@ -19990,15 +20076,15 @@
         },
         {
           "vuid": "VUID-vkCmdWriteAccelerationStructurePropertiesNVX-commonparent",
-          "text": " Each of <code>accelerationStructure</code>, <code>cmdBuf</code>, and <code>queryPool</code> <strong class=\"purple\">must</strong> have been created, allocated, or retrieved from the same <code>VkDevice</code>"
+          "text": " Each of <code>accelerationStructure</code>, <code>commandBuffer</code>, and <code>queryPool</code> <strong class=\"purple\">must</strong> have been created, allocated, or retrieved from the same <code>VkDevice</code>"
         }
       ]
     },
     "vkCmdCopyAccelerationStructureNVX": {
       "(VK_NVX_raytracing)": [
         {
-          "vuid": "VUID-vkCmdCopyAccelerationStructureNVX-cmdBuf-parameter",
-          "text": " <code>cmdBuf</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
+          "vuid": "VUID-vkCmdCopyAccelerationStructureNVX-commandBuffer-parameter",
+          "text": " <code>commandBuffer</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
         },
         {
           "vuid": "VUID-vkCmdCopyAccelerationStructureNVX-dst-parameter",
@@ -20022,7 +20108,7 @@
         },
         {
           "vuid": "VUID-vkCmdCopyAccelerationStructureNVX-commonparent",
-          "text": " Each of <code>cmdBuf</code>, <code>dst</code>, and <code>src</code> <strong class=\"purple\">must</strong> have been created, allocated, or retrieved from the same <code>VkDevice</code>"
+          "text": " Each of <code>commandBuffer</code>, <code>dst</code>, and <code>src</code> <strong class=\"purple\">must</strong> have been created, allocated, or retrieved from the same <code>VkDevice</code>"
         }
       ]
     },
@@ -20147,6 +20233,14 @@
         {
           "vuid": "VUID-VkPhysicalDeviceMultiviewFeatures-sType-sType",
           "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES</code>"
+        }
+      ]
+    },
+    "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+      "(VK_KHR_shader_atomic_int64)": [
+        {
+          "vuid": "VUID-VkPhysicalDeviceShaderAtomicInt64FeaturesKHR-sType-sType",
+          "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR</code>"
         }
       ]
     },
@@ -20535,6 +20629,12 @@
       ]
     },
     "vkGetPhysicalDeviceImageFormatProperties": {
+      "(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-vkGetPhysicalDeviceImageFormatProperties-tiling-02248",
+          "text": " <code>tiling</code> <strong class=\"purple\">must</strong> not be <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code>. (Use <a href=\"#vkGetPhysicalDeviceImageFormatProperties2\">vkGetPhysicalDeviceImageFormatProperties2</a> instead)."
+        }
+      ],
       "core": [
         {
           "vuid": "VUID-vkGetPhysicalDeviceImageFormatProperties-physicalDevice-parameter",
@@ -20633,6 +20733,12 @@
       ]
     },
     "VkPhysicalDeviceImageFormatInfo2": {
+      "(VK_VERSION_1_1,VK_KHR_get_physical_device_properties2)+(VK_EXT_image_drm_format_modifier)": [
+        {
+          "vuid": "VUID-VkPhysicalDeviceImageFormatInfo2KHR-tiling-02249",
+          "text": " <code>tiling</code> <strong class=\"purple\">must</strong> be <code>VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT</code> if and only if the <code>pNext</code> chain contains <a href=\"#VkPhysicalDeviceImageDrmFormatModifierInfoEXT\">VkPhysicalDeviceImageDrmFormatModifierInfoEXT</a>."
+        }
+      ],
       "(VK_VERSION_1_1,VK_KHR_get_physical_device_properties2)": [
         {
           "vuid": "VUID-VkPhysicalDeviceImageFormatInfo2-sType-sType",

--- a/registry/vk.xml
+++ b/registry/vk.xml
@@ -55,6 +55,7 @@ server.
         <platform name="vi" protect="VK_USE_PLATFORM_VI_NN" comment="Nintendo Vi"/>
         <platform name="ios" protect="VK_USE_PLATFORM_IOS_MVK" comment="Apple IOS"/>
         <platform name="macos" protect="VK_USE_PLATFORM_MACOS_MVK" comment="Apple MacOS"/>
+        <platform name="fuchsia" protect="VK_USE_PLATFORM_FUCHSIA" comment="Fuchsia"/>
     </platforms>
 
     <tags comment="Vulkan vendor/author tags for extensions and layers">
@@ -99,13 +100,14 @@ server.
         <type category="include" name="wayland-client.h"/>
         <type category="include" name="windows.h"/>
         <type category="include" name="xcb/xcb.h"/>
+        <type category="include" name="zircon/types.h"/>
             <comment>
                 In the current header structure, each platform's interfaces
                 are confined to a platform-specific header (vulkan_xlib.h,
                 vulkan_win32.h, etc.). These headers are not self-contained,
                 and should not include native headers (X11/Xlib.h,
                 windows.h, etc.). Code should either include vulkan.h after
-                defining the appropriate VK_USE_PLATFORM_platform_KHR
+                defining the appropriate VK_USE_PLATFORM_platform
                 macros, or include the required native headers prior to
                 explicitly including the corresponding platform header.
 
@@ -133,6 +135,7 @@ server.
         <type requires="xcb/xcb.h" name="xcb_connection_t"/>
         <type requires="xcb/xcb.h" name="xcb_visualid_t"/>
         <type requires="xcb/xcb.h" name="xcb_window_t"/>
+        <type requires="zircon/types.h" name="zx_handle_t"/>
 
         <type category="define">#define <name>VK_MAKE_VERSION</name>(major, minor, patch) \
     (((major) &lt;&lt; 22) | ((minor) &lt;&lt; 12) | (patch))</type>
@@ -147,7 +150,7 @@ server.
         <type category="define">// Vulkan 1.1 version number
 #define <name>VK_API_VERSION_1_1</name> <type>VK_MAKE_VERSION</type>(1, 1, 0)// Patch version should always be set to 0</type>
         <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 85</type>
+#define <name>VK_HEADER_VERSION</name> 87</type>
 
         <type category="define">
 #define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* object;</type>
@@ -270,6 +273,7 @@ server.
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkXcbSurfaceCreateFlagsKHR</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkIOSSurfaceCreateFlagsMVK</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMacOSSurfaceCreateFlagsMVK</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkImagePipeSurfaceCreateFlagsFUCHSIA</name>;</type>
         <type requires="VkPeerMemoryFeatureFlagBits"   category="bitmask">typedef <type>VkFlags</type> <name>VkPeerMemoryFeatureFlags</name>;</type>
         <type                                             category="bitmask" name="VkPeerMemoryFeatureFlagsKHR"               alias="VkPeerMemoryFeatureFlags"/>
         <type requires="VkMemoryAllocateFlagBits"      category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryAllocateFlags</name>;</type>
@@ -523,6 +527,7 @@ server.
 
             <comment>Enumerated types in the header, but not used by the API</comment>
         <type name="VkVendorId" category="enum"/>
+        <type name="VkDriverIdKHR" category="enum"/>
         <type name="VkShadingRatePaletteEntryNV" category="enum"/>
         <type name="VkCoarseSampleOrderTypeNV" category="enum"/>
 
@@ -1124,7 +1129,7 @@ server.
             <member values="VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineDynamicStateCreateFlags</type>    <name>flags</name></member>
-            <member><type>uint32_t</type>               <name>dynamicStateCount</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>dynamicStateCount</name></member>
             <member len="dynamicStateCount">const <type>VkDynamicState</type>*  <name>pDynamicStates</name></member>
         </type>
         <type category="struct" name="VkStencilOpState">
@@ -1676,6 +1681,12 @@ server.
             <member noautovalidity="true"><type>xcb_connection_t</type>*                <name>connection</name></member>
             <member><type>xcb_window_t</type>                     <name>window</name></member>
         </type>
+        <type category="struct" name="VkImagePipeSurfaceCreateInfoFUCHSIA">
+            <member values="VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>VkImagePipeSurfaceCreateFlagsFUCHSIA</type>   <name>flags</name></member>
+            <member><type>zx_handle_t</type>                      <name>imagePipeHandle</name></member>
+        </type>
         <type category="struct" name="VkSurfaceFormatKHR" returnedonly="true">
             <member><type>VkFormat</type>                         <name>format</name><comment>Supported pair of rendering format</comment></member>
             <member><type>VkColorSpaceKHR</type>                  <name>colorSpace</name><comment>and color space for the surface</comment></member>
@@ -1971,6 +1982,20 @@ server.
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>maxPushDescriptors</name></member>
+        </type>
+        <type category="struct" name="VkConformanceVersionKHR">
+            <member><type>uint8_t</type>                          <name>major</name></member>
+            <member><type>uint8_t</type>                          <name>minor</name></member>
+            <member><type>uint8_t</type>                          <name>subminor</name></member>
+            <member><type>uint8_t</type>                          <name>patch</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceDriverPropertiesKHR" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>driverID</name></member>
+            <member><type>char</type>                             <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE_KHR</enum>]</member>
+            <member><type>char</type>                             <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE_KHR</enum>]</member>
+            <member><type>VkConformanceVersionKHR</type>          <name>conformanceVersion</name></member>
         </type>
         <type category="struct" name="VkPresentRegionsKHR" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -2761,10 +2786,10 @@ server.
         </type>
         <type category="struct" name="VkSampleLocationsInfoEXT" structextends="VkImageMemoryBarrier">
             <member values="VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>
-            <member><type>VkSampleCountFlagBits</type>            <name>sampleLocationsPerPixel</name></member>
-            <member><type>VkExtent2D</type>                       <name>sampleLocationGridSize</name></member>
-            <member><type>uint32_t</type>                         <name>sampleLocationsCount</name></member>
+            <member>const <type>void</type>*                            <name>pNext</name></member>
+            <member optional="true"><type>VkSampleCountFlagBits</type>  <name>sampleLocationsPerPixel</name></member>
+            <member><type>VkExtent2D</type>                             <name>sampleLocationGridSize</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>sampleLocationsCount</name></member>
             <member len="sampleLocationsCount">const <type>VkSampleLocationEXT</type>* <name>pSampleLocations</name></member>
         </type>
         <type category="struct" name="VkAttachmentSampleLocationsEXT">
@@ -3243,6 +3268,12 @@ server.
             <member><type>VkBool32</type>                         <name>vulkanMemoryModel</name></member>
             <member><type>VkBool32</type>                         <name>vulkanMemoryModelDeviceScope</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceShaderAtomicInt64FeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                               <name>pNext</name></member>
+            <member><type>VkBool32</type>                            <name>shaderBufferInt64Atomics</name></member>
+            <member><type>VkBool32</type>                            <name>shaderSharedInt64Atomics</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
@@ -3464,6 +3495,40 @@ server.
             <member><type>uint32_t</type>                         <name>maxRecursionDepth</name></member>
             <member><type>uint32_t</type>                         <name>maxGeometryCount</name></member>
         </type>
+        <type category="struct" name="VkDrmFormatModifierPropertiesListEXT" structextends="VkFormatProperties2">
+            <member values="VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type> <name>drmFormatModifierCount</name></member>
+            <member optional="true,false" len="drmFormatModifierCount"><type>VkDrmFormatModifierPropertiesEXT</type>* <name>pDrmFormatModifierProperties</name></member>
+        </type>
+        <type category="struct" name="VkDrmFormatModifierPropertiesEXT" returnedonly="true">
+            <member><type>uint64_t</type> <name>drmFormatModifier</name></member>
+            <member><type>uint32_t</type> <name>drmFormatModifierPlaneCount</name></member>
+            <member><type>VkFormatFeatureFlags</type> <name>drmFormatModifierTilingFeatures</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceImageDrmFormatModifierInfoEXT" structextends="VkPhysicalDeviceImageFormatInfo2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>* <name>pNext</name></member>
+            <member><type>uint64_t</type> <name>drmFormatModifier</name></member>
+        </type>
+        <type category="struct" name="VkImageDrmFormatModifierListCreateInfoEXT" structextends="VkImageCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>* <name>pNext</name></member>
+            <member><type>uint32_t</type> <name>drmFormatModifierCount</name></member>
+            <member len="drmFormatModifierCount">const <type>uint64_t</type>* <name>pDrmFormatModifiers</name></member>
+        </type>
+        <type category="struct" name="VkImageDrmFormatModifierExplicitCreateInfoEXT" structextends="VkImageCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_EXCPLICIT_DRM_FORMAT_MODIFIER_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>* <name>pNext</name></member>
+            <member><type>uint64_t</type> <name>drmFormatModifier</name></member>
+            <member optional="false"><type>uint32_t</type> <name>drmFormatModifierPlaneCount</name></member>
+            <member len="drmFormatModifierPlaneCount">const <type>VkSubresourceLayout</type>* <name>pPlaneLayouts</name></member>
+        </type>
+        <type category="struct" name="VkImageDrmFormatModifierPropertiesEXT" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>* <name>pNext</name></member>
+            <member><type>uint64_t</type> <name>drmFormatModifier</name></member>
+        </type>
     </types>
 
     <comment>Vulkan enumerant (token) definitions</comment>
@@ -3491,6 +3556,8 @@ server.
         <enum value="(~0U)" name="VK_SUBPASS_EXTERNAL"/>
         <enum value="32"    name="VK_MAX_DEVICE_GROUP_SIZE"/>
         <enum               name="VK_MAX_DEVICE_GROUP_SIZE_KHR" alias="VK_MAX_DEVICE_GROUP_SIZE"/>
+        <enum value="256"   name="VK_MAX_DRIVER_NAME_SIZE_KHR"/>
+        <enum value="256"   name="VK_MAX_DRIVER_INFO_SIZE_KHR"/>
     </enums>
 
     <comment>
@@ -4043,6 +4110,7 @@ server.
         <enum bitpos="2"    name="VK_QUEUE_TRANSFER_BIT"                             comment="Queue supports transfer operations"/>
         <enum bitpos="3"    name="VK_QUEUE_SPARSE_BINDING_BIT"                       comment="Queue supports sparse resource memory management operations"/>
     </enums>
+    <enums name="VkRenderPassCreateFlagBits" type="bitmask"></enums>
     <enums name="VkDeviceQueueCreateFlagBits" type="bitmask"></enums>
     <enums name="VkMemoryPropertyFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT"               comment="If otherwise stated, then allocate memory on device"/>
@@ -4548,6 +4616,20 @@ server.
         <enum value="0x10002" name="VK_VENDOR_ID_VSI"   comment="VeriSilicon vendor ID"/>
         <enum value="0x10003" name="VK_VENDOR_ID_KAZAN" comment="Kazan Software Renderer"/>
             <unused start="0x10004" comment="This is the next unused available Khronos vendor ID"/>
+    </enums>
+    <enums name="VkDriverIdKHR" type="enum">
+        <comment>Driver IDs are now represented as enums instead of the old
+                 &lt;driverids&gt; tag, allowing them to be included in the
+                 API headers.</comment>
+        <enum value="1"       name="VK_DRIVER_ID_AMD_PROPRIETARY_KHR"           comment="Advanced Micro Devices, Inc."/>
+        <enum value="2"       name="VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR"           comment="Advanced Micro Devices, Inc."/>
+        <enum value="3"       name="VK_DRIVER_ID_MESA_RADV_KHR"                 comment="Mesa open source project"/>
+        <enum value="4"       name="VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR"        comment="NVIDIA Corporation"/>
+        <enum value="5"       name="VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR" comment="Intel Corporation"/>
+        <enum value="6"       name="VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR"    comment="Intel Corporation"/>
+        <enum value="7"       name="VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR"   comment="Imagination Technologies"/>
+        <enum value="8"       name="VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"      comment="Qualcomm Technologies, Inc."/>
+        <enum value="9"       name="VK_DRIVER_ID_ARM_PROPRIETARY_KHR"           comment="Arm Limited"/>
     </enums>
     <enums name="VkConditionalRenderingFlagBitsEXT" type="bitmask">
         <enum bitpos="0"    name="VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT"/>
@@ -5765,6 +5847,13 @@ server.
             <param><type>xcb_connection_t</type>* <name>connection</name></param>
             <param><type>xcb_visualid_t</type> <name>visual_id</name></param>
         </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateImagePipeSurfaceFUCHSIA</name></proto>
+            <param><type>VkInstance</type> <name>instance</name></param>
+            <param>const <type>VkImagePipeSurfaceCreateInfoFUCHSIA</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkSurfaceKHR</type>* <name>pSurface</name></param>
+        </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY">
             <proto><type>VkResult</type> <name>vkCreateDebugReportCallbackEXT</name></proto>
             <param><type>VkInstance</type> <name>instance</name></param>
@@ -6658,14 +6747,14 @@ server.
         </command>
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdCopyAccelerationStructureNVX</name></proto>
-            <param><type>VkCommandBuffer</type> <name>cmdBuf</name></param>
+            <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>VkAccelerationStructureNVX</type> <name>dst</name></param>
             <param><type>VkAccelerationStructureNVX</type> <name>src</name></param>
             <param><type>VkCopyAccelerationStructureModeNVX</type> <name>mode</name></param>
         </command>
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdWriteAccelerationStructurePropertiesNVX</name></proto>
-            <param><type>VkCommandBuffer</type> <name>cmdBuf</name></param>
+            <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>VkAccelerationStructureNVX</type> <name>accelerationStructure</name></param>
             <param><type>VkQueryType</type> <name>queryType</name></param>
             <param><type>VkQueryPool</type> <name>queryPool</name></param>
@@ -6673,7 +6762,7 @@ server.
         </command>
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdBuildAccelerationStructureNVX</name></proto>
-            <param><type>VkCommandBuffer</type> <name>cmdBuf</name></param>
+            <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>VkAccelerationStructureTypeNVX</type> <name>type</name></param>
             <param optional="true"><type>uint32_t</type> <name>instanceCount</name></param>
             <param optional="true"><type>VkBuffer</type> <name>instanceData</name></param>
@@ -6689,7 +6778,7 @@ server.
         </command>
         <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdTraceRaysNVX</name></proto>
-            <param><type>VkCommandBuffer</type> <name>cmdBuf</name></param>
+            <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>VkBuffer</type> <name>raygenShaderBindingTableBuffer</name></param>
             <param><type>VkDeviceSize</type> <name>raygenShaderBindingOffset</name></param>
             <param><type>VkBuffer</type> <name>missShaderBindingTableBuffer</name></param>
@@ -6725,6 +6814,12 @@ server.
             <param len="createInfoCount">const <type>VkRaytracingPipelineCreateInfoNVX</type>* <name>pCreateInfos</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param len="createInfoCount"><type>VkPipeline</type>* <name>pPipelines</name></param>
+        </command>
+        <command>
+            <proto><type>VkResult</type> <name>vkGetImageDrmFormatModifierPropertiesEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkImage</type> <name>image</name></param>
+            <param><type>VkImageDrmFormatModifierPropertiesEXT</type>* <name>pProperties</name></param>
         </command>
     </commands>
 
@@ -7408,7 +7503,7 @@ server.
                 <command name="vkGetPhysicalDeviceWaylandPresentationSupportKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_mir_surface" number="8" type="instance" requires="VK_KHR_surface" platform="mir" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_KHR_mir_surface" number="8" type="instance" requires="VK_KHR_surface" platform="mir" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" obsoletedby="" supported="vulkan">
             <require>
                 <enum value="4"                                                 name="VK_KHR_MIR_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_mir_surface&quot;"                    name="VK_KHR_MIR_SURFACE_EXTENSION_NAME"/>
@@ -9115,10 +9210,38 @@ server.
                 <type name="VkBindImageMemoryInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_159" number="159" author="EXT" contact="Chad Versace @chadversary" supported="disabled">
+        <extension name="VK_EXT_image_drm_format_modifier" number="159" type="device" requires="VK_KHR_bind_memory2,VK_KHR_get_physical_device_properties2,VK_KHR_sampler_ycbcr_conversion" author="EXT" contact="Chad Versace @chadversary" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_EXT_EXTENSION_159_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_159&quot;"              name="VK_EXT_EXTENSION_159_EXTENSION_NAME"/>
+
+                <enum value="1" name="VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_image_drm_format_modifier&quot;" name="VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME"/>
+
+                <enum offset="0" dir="-" extends="VkResult" name="VK_ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT"/>
+
+                <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT"/>
+                <enum offset="1" extends="VkStructureType" name="VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT"/>
+                <enum offset="2" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT"/>
+                <enum offset="3" extends="VkStructureType" name="VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT"/>
+                <enum offset="4" extends="VkStructureType" name="VK_STRUCTURE_TYPE_IMAGE_EXCPLICIT_DRM_FORMAT_MODIFIER_CREATE_INFO_EXT"/>
+                <enum offset="5" extends="VkStructureType" name="VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT"/>
+
+                <enum offset="0" extends="VkImageTiling" name="VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT"/>
+
+                <enum bitpos="7"  extends="VkImageAspectFlagBits" name="VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT"/>
+                <enum bitpos="8"  extends="VkImageAspectFlagBits" name="VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT"/>
+                <enum bitpos="9"  extends="VkImageAspectFlagBits" name="VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT"/>
+                <enum bitpos="10" extends="VkImageAspectFlagBits" name="VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT"/>
+
+                <type name="VkDrmFormatModifierPropertiesListEXT"/>
+                <type name="VkDrmFormatModifierPropertiesEXT"/>
+                <type name="VkPhysicalDeviceImageDrmFormatModifierInfoEXT"/>
+                <type name="VkImageDrmFormatModifierListCreateInfoEXT"/>
+                <type name="VkImageDrmFormatModifierExplicitCreateInfoEXT"/>
+                <type name="VkImageDrmFormatModifierPropertiesEXT"/>
+
+                <command name="vkGetImageDrmFormatModifierPropertiesEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_160" number="160" author="EXT" contact="Mark Young @marky-lunarg" supported="disabled">
@@ -9383,10 +9506,12 @@ server.
                 <command name="vkCmdWriteBufferMarkerAMD"/>
             </require>
         </extension>
-        <extension name="VK_AMD_extension_181" number="181" author="AMD" contact="Daniel Rakos @drakos-amd" supported="disabled">
+        <extension name="VK_KHR_shader_atomic_int64" number="181" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Aaron Hagan @ahagan" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_KHR_EXTENSION_181_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_extension_181&quot;"              name="VK_KHR_EXTENSION_181_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_KHR_SHADER_ATOMIC_INT64_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_shader_atomic_int64&quot;"        name="VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR"/>
+                <type name="VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"/>
             </require>
         </extension>
         <extension name="VK_AMD_extension_182" number="182" author="AMD" contact="Daniel Rakos @drakos-amd" supported="disabled">
@@ -9488,10 +9613,16 @@ server.
                 <enum value="&quot;VK_GOOGLE_extension_196&quot;"       name="VK_GOOGLE_EXTENSION_196_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_197" number="197" author="Baldur Karlsson" contact="Baldur Karlsson @baldurk" supported="disabled">
+        <extension name="VK_KHR_driver_properties" number="197" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Daniel Rakos @drakos-amd" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_EXT_EXTENSION_197_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_197&quot;"          name="VK_EXT_EXTENSION_197_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_DRIVER_PROPERTIES_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_driver_properties&quot;"      name="VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR"/>
+                <enum name="VK_MAX_DRIVER_NAME_SIZE_KHR"/>
+                <enum name="VK_MAX_DRIVER_INFO_SIZE_KHR"/>
+                <type name="VkDriverIdKHR"/>
+                <type name="VkConformanceVersionKHR"/>
+                <type name="VkPhysicalDeviceDriverPropertiesKHR"/>
             </require>
         </extension>
         <extension name="VK_ARM_extension_198" number="198" author="Alexander Galazin" contact="Alexander Galazin @alegal-arm" supported="disabled">
@@ -9629,10 +9760,14 @@ server.
                 <enum value="&quot;VK_KHR_extension_214&quot;"              name="VK_KHR_EXTENSION_214_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_GOOGLE_extension_215" number="215" author="GOOGLE" contact="Jesse Hall @critsec" supported="disabled">
+        <extension name="VK_FUCHSIA_imagepipe_surface" number="215" type="instance" author="FUCHSIA" requires="VK_KHR_surface" platform="fuchsia" contact="Craig Stout @cdotstout" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_KHR_EXTENSION_215_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_215&quot;"              name="VK_KHR_EXTENSION_215_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_FUCHSIA_IMAGEPIPE_SURFACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_FUCHSIA_imagepipe_surface&quot;"  name="VK_FUCHSIA_IMAGEPIPE_SURFACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA"/>
+                <type name="VkImagePipeSurfaceCreateFlagsFUCHSIA"/>
+                <type name="VkImagePipeSurfaceCreateInfoFUCHSIA"/>
+                <command name="vkCreateImagePipeSurfaceFUCHSIA"/>
             </require>
         </extension>
         <extension name="VK_GOOGLE_extension_216" number="216" author="GOOGLE" contact="Jesse Hall @critsec" supported="disabled">
@@ -9668,6 +9803,109 @@ server.
             <require>
                 <enum value="0"                                              name="VK_EXT_EXTENSION_220_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_220&quot;"               name="VK_EXT_EXTENSION_220_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_221" number="221" author="KHR" contact="Tobias Hector @tobski" supported="disabled">
+            <require>
+                <enum value="0"                                              name="VK_KHR_EXTENSION_221_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_221&quot;"               name="VK_KHR_EXTENSION_221_EXTENSION_NAME"/>
+                <enum bitpos="0" extends="VkRenderPassCreateFlagBits"        name="VK_RENDER_PASS_CREATE_RESERVED_0_BIT_KHR"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_222" number="222" author="EXT" contact="Tobias Hector @tobski" supported="disabled">
+            <require>
+                <enum value="0"                                              name="VK_EXT_EXTENSION_222_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_222&quot;"               name="VK_EXT_EXTENSION_222_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_223" number="223" author="EXT" contact="Tobias Hector @tobski" supported="disabled">
+            <require>
+                <enum value="0"                                              name="VK_EXT_EXTENSION_223_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_223&quot;"               name="VK_EXT_EXTENSION_223_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_224" number="224" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_224_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_224&quot;"              name="VK_AMD_EXTENSION_224_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_225" number="225" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_225_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_225&quot;"              name="VK_AMD_EXTENSION_225_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_226" number="226" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_226_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_226&quot;"              name="VK_AMD_EXTENSION_226_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_227" number="227" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_227_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_227&quot;"              name="VK_AMD_EXTENSION_227_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_228" number="228" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_228_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_228&quot;"              name="VK_AMD_EXTENSION_228_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_229" number="229" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_229_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_229&quot;"              name="VK_AMD_EXTENSION_229_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_230" number="230" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_230_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_230&quot;"              name="VK_AMD_EXTENSION_230_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_231" number="231" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_231_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_231&quot;"              name="VK_AMD_EXTENSION_231_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_232" number="232" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_232_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_232&quot;"              name="VK_AMD_EXTENSION_232_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_233" number="233" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_233_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_233&quot;"              name="VK_AMD_EXTENSION_233_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_234" number="234" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_234_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_234&quot;"              name="VK_AMD_EXTENSION_234_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_235" number="235" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_235_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_235&quot;"              name="VK_AMD_EXTENSION_235_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_236" number="236" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_AMD_EXTENSION_236_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_236&quot;"              name="VK_AMD_EXTENSION_236_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_237" number="237" author="KHR" contact="Jesse Hall @critsec" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_237_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_237&quot;"              name="VK_KHR_EXTENSION_237_EXTENSION_NAME"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Updated:
- include/vulkan/vulkan.h
- include/vulkan/vulkan.hpp
- include/vulkan/vulkan_core.h
- registry/genvk.py
- registry/reg.py
- registry/validusage.json
- registry/vk.xml

Added:
- include/vulkan/vulkan_fuchsia.h

Note: A local, modified version of Vulkan-Docs/xml/reg.py was used to
generate these files. This modification filters out disabled extensions
when populating the structextends list for a given base struct.