### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/registry/cgenerator.py
+++ b/registry/cgenerator.py
@@ -189,7 +189,7 @@ class COutputGenerator(OutputGenerator):
             # If type declarations are needed by other features based on
             # this one, it may be necessary to suppress the ExtraProtect,
             # or move it below the 'for section...' loop.
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#ifdef', self.featureExtraProtect, file=self.outFile)
             write('#define', self.featureName, '1', file=self.outFile)
             for section in self.TYPE_SECTIONS:
@@ -209,7 +209,7 @@ class COutputGenerator(OutputGenerator):
                     write('#endif', file=self.outFile)
                 else:
                     self.newline()
-            if (self.featureExtraProtect != None):
+            if (self.featureExtraProtect is not None):
                 write('#endif /*', self.featureExtraProtect, '*/', file=self.outFile)
             if (self.genOpts.protectFeature):
                 write('#endif /*', self.featureName, '*/', file=self.outFile)
@@ -351,14 +351,14 @@ class COutputGenerator(OutputGenerator):
                 # Extension enumerants are only included if they are required
                 if self.isEnumRequired(elem):
                     decl = "    " + name + " = " + strVal + ",\n"
-                    if numVal != None:
+                    if numVal is not None:
                         body += decl
                     else:
                         aliasText += decl
 
                 # Don't track min/max for non-numbers (numVal == None)
-                if isEnum and numVal != None and elem.get('extends') is None:
-                    if minName == None:
+                if isEnum and numVal is not None and elem.get('extends') is None:
+                    if minName is None:
                         minName = maxName = name
                         minValue = maxValue = numVal
                     elif numVal < minValue:

--- a/registry/generator.py
+++ b/registry/generator.py
@@ -146,7 +146,7 @@ class GeneratorOptions:
     # Substitute a regular expression which matches no version
     # or extension names for None or the empty string.
     def emptyRegex(self,pat):
-        if (pat == None or pat == ''):
+        if (pat is None or pat == ''):
             return '_nomatch_^'
         else:
             return pat
@@ -236,14 +236,14 @@ class OutputGenerator:
         if (level == 'error'):
             strfile = io.StringIO()
             write('ERROR:', *args, file=strfile)
-            if (self.errFile != None):
+            if (self.errFile is not None):
                 write(strfile.getvalue(), file=self.errFile)
             raise UserWarning(strfile.getvalue())
         elif (level == 'warn'):
-            if (self.warnFile != None):
+            if (self.warnFile is not None):
                 write('WARNING:', *args, file=self.warnFile)
         elif (level == 'diag'):
-            if (self.diagFile != None):
+            if (self.diagFile is not None):
                 write('DIAG:', *args, file=self.diagFile)
         else:
             raise UserWarning(
@@ -279,7 +279,7 @@ class OutputGenerator:
             # If there's a non-integer, numeric 'type' attribute (e.g. 'u' or
             # 'ull'), append it to the string value.
             # t = enuminfo.elem.get('type')
-            # if (t != None and t != '' and t != 'i' and t != 's'):
+            # if (t is not None and t != '' and t != 'i' and t != 's'):
             #     value += enuminfo.type
             self.logMsg('diag', 'Enum', name, '-> value [', numVal, ',', value, ']')
             return [numVal, value]
@@ -336,7 +336,7 @@ class OutputGenerator:
                 # Duplicate enum values for the same name are benign. This
                 # happens when defining the same enum conditionally in
                 # several extension blocks.
-                if (strVal2 == strVal or (numVal != None and
+                if (strVal2 == strVal or (numVal is not None and
                     numVal == numVal2)):
                     True
                     # self.logMsg('info', 'checkDuplicateEnums: Duplicate enum (' + name +
@@ -361,7 +361,7 @@ class OutputGenerator:
 
             # Track this enum to detect followon duplicates
             nameMap[name] = [ elem, numVal, strVal ]
-            if numVal != None:
+            if numVal is not None:
                 valueMap[numVal] = [ elem, numVal, strVal ]
 
             # Add this enum to the list
@@ -384,7 +384,7 @@ class OutputGenerator:
         #
         # Open specified output file. Not done in constructor since a
         # Generator can be used without writing to a file.
-        if (self.genOpts.filename != None):
+        if (self.genOpts.filename is not None):
             filename = self.genOpts.directory + '/' + self.genOpts.filename
             self.outFile = io.open(filename, 'w', encoding='utf-8')
         else:
@@ -410,7 +410,7 @@ class OutputGenerator:
     # Utility method to validate we're generating something only inside a
     # <feature> tag
     def validateFeature(self, featureType, featureName):
-        if (self.featureName == None):
+        if (self.featureName is None):
             raise UserWarning('Attempt to generate', featureType,
                     featureName, 'when not in feature')
     #
@@ -495,7 +495,7 @@ class OutputGenerator:
     # required, False otherwise
     # elem - <enum> element to test
     def isEnumRequired(self, elem):
-        required = elem.get('required') != None
+        required = elem.get('required') is not None
         self.logMsg('diag', 'isEnumRequired:', elem.get('name'),
             '->', required)
         return required

--- a/registry/genvk.py
+++ b/registry/genvk.py
@@ -41,7 +41,7 @@ def endTimer(timeit, msg):
 
 # Turn a list of strings into a regexp string matching exactly those strings
 def makeREstring(list, default = None):
-    if len(list) > 0 or default == None:
+    if len(list) > 0 or default is None:
         return '^(' + '|'.join(list) + ')$'
     else:
         return default

--- a/registry/reg.py
+++ b/registry/reg.py
@@ -51,14 +51,14 @@ def matchAPIProfile(api, profile, elem):
     match = True
     # Match 'api', if present
     if ('api' in elem.attrib):
-        if (api == None):
+        if (api is None):
             raise UserWarning("No API requested, but 'api' attribute is present with value '" +
                               elem.get('api') + "'")
         elif (api != elem.get('api')):
             # Requested API doesn't match attribute
             return False
     if ('profile' in elem.attrib):
-        if (profile == None):
+        if (profile is None):
             raise UserWarning("No profile requested, but 'profile' attribute is present with value '" +
                 elem.get('profile') + "'")
         elif (profile != elem.get('profile')):
@@ -134,7 +134,7 @@ class EnumInfo(BaseInfo):
     def __init__(self, elem):
         BaseInfo.__init__(self, elem)
         self.type = elem.get('type')
-        if (self.type == None):
+        if (self.type is None):
             self.type = ''
 
 # CmdInfo - registry information about a command
@@ -309,7 +309,7 @@ class Registry:
         for type in self.reg.findall('types/type'):
             # If the <type> doesn't already have a 'name' attribute, set
             # it from contents of its <name> tag.
-            if (type.get('name') == None):
+            if (type.get('name') is None):
                 type.attrib['name'] = type.find('name').text
             self.addElementInfo(type, TypeInfo(type), 'type', self.typedict)
         #
@@ -333,7 +333,7 @@ class Registry:
         # a better scheme for tagging core and extension enums is created.
         self.enumdict = {}
         for enums in self.reg.findall('enums'):
-            required = (enums.get('type') != None)
+            required = (enums.get('type') is not None)
             for enum in enums.findall('enum'):
                 enumInfo = EnumInfo(enum)
                 enumInfo.required = required
@@ -356,7 +356,7 @@ class Registry:
             # If the <command> doesn't already have a 'name' attribute, set
             # it from contents of its <proto><name> tag.
             name = cmd.get('name')
-            if name == None:
+            if name is None:
                 name = cmd.attrib['name'] = cmd.find('proto/name').text
             ci = CmdInfo(cmd)
             self.addElementInfo(cmd, ci, 'command', self.cmddict)
@@ -423,7 +423,7 @@ class Registry:
               for enum in elem.findall('enum'):
                 addEnumInfo = False
                 groupName = enum.get('extends')
-                if (groupName != None):
+                if (groupName is not None):
                     # self.gen.logMsg('diag', 'Found extension enum',
                     #     enum.get('name'))
                     # Add version number attribute to the <enum> element
@@ -466,7 +466,7 @@ class Registry:
               for enum in elem.findall('enum'):
                 addEnumInfo = False
                 groupName = enum.get('extends')
-                if (groupName != None):
+                if (groupName is not None):
                     # self.gen.logMsg('diag', 'Found extension enum',
                     #     enum.get('name'))
 
@@ -509,7 +509,7 @@ class Registry:
         for type in self.reg.findall('types/type'):
             if type.get('name') not in disabled_types:
                 parentStructs = type.get('structextends')
-                if (parentStructs != None):
+                if (parentStructs is not None):
                     for parent in parentStructs.split(','):
                         # self.gen.logMsg('diag', type.get('name'), 'extends', parent)
                         self.validextensionstructs[parent].append(type.get('name'))
@@ -558,7 +558,7 @@ class Registry:
         self.gen.logMsg('diag', 'tagging type:', typename, '-> required =', required)
         # Get TypeInfo object for <type> tag corresponding to typename
         type = self.lookupElementInfo(typename, self.typedict)
-        if (type != None):
+        if (type is not None):
             if (required):
                 # Tag type dependencies in 'alias' and 'required' attributes as
                 # required. This DOES NOT un-tag dependencies in a <remove>
@@ -597,7 +597,7 @@ class Registry:
     def markEnumRequired(self, enumname, required):
         self.gen.logMsg('diag', 'tagging enum:', enumname, '-> required =', required)
         enum = self.lookupElementInfo(enumname, self.enumdict)
-        if (enum != None):
+        if (enum is not None):
             enum.required = required
             # Tag enum dependencies in 'alias' attribute as required
             depname = enum.elem.get('alias')
@@ -613,7 +613,7 @@ class Registry:
     def markCmdRequired(self, cmdname, required):
         self.gen.logMsg('diag', 'tagging command:', cmdname, '-> required =', required)
         cmd = self.lookupElementInfo(cmdname, self.cmddict)
-        if (cmd != None):
+        if (cmd is not None):
             cmd.required = required
             # Tag command dependencies in 'alias' attribute as required
             depname = cmd.elem.get('alias')
@@ -699,7 +699,7 @@ class Registry:
 
         self.gen.logMsg('diag', 'generateFeature: generating', ftype, fname)
         f = self.lookupElementInfo(fname, dictionary)
-        if (f == None):
+        if (f is None):
             # No such feature. This is an error, but reported earlier
             self.gen.logMsg('diag', 'No entry found for feature', fname,
                             'returning!')
@@ -760,7 +760,7 @@ class Registry:
             if (f.elem.get('category') == 'enum'):
                 self.gen.logMsg('diag', 'Type', fname, 'is an enum group, so generate that instead')
                 group = self.lookupElementInfo(fname, self.groupdict)
-                if alias != None:
+                if alias is not None:
                     # An alias of another group name.
                     # Pass to genGroup with 'alias' parameter = aliased name
                     self.gen.logMsg('diag', 'Generating alias', fname,
@@ -769,7 +769,7 @@ class Registry:
                     # with an additional parameter which is the alias name.
                     genProc = self.gen.genGroup
                     f = self.lookupElementInfo(alias, self.groupdict)
-                elif group == None:
+                elif group is None:
                     self.gen.logMsg('warn', 'Skipping enum type', fname,
                         ': No matching enumerant group')
                     return
@@ -905,7 +905,7 @@ class Registry:
                     # Matches API & version #s being generated. Mark for
                     # emission and add to the features[] list .
                     # @@ Could use 'declared' instead of 'emit'?
-                    fi.emit = (regEmitVersions.match(fi.name) != None)
+                    fi.emit = (regEmitVersions.match(fi.name) is not None)
                     features.append(fi)
                     if (not fi.emit):
                         self.gen.logMsg('diag', 'NOT tagging feature api =', api,
@@ -951,7 +951,7 @@ class Registry:
             # the regexp specified in the generator options. This allows
             # forcing extensions into an interface even if they're not
             # tagged appropriately in the registry.
-            if (regAddExtensions.match(extName) != None):
+            if (regAddExtensions.match(extName) is not None):
                 self.gen.logMsg('diag', 'Including extension',
                     extName, '(matches explicitly requested extensions to add)')
                 include = True
@@ -959,7 +959,7 @@ class Registry:
             # in generator options. This allows forcing removal of
             # extensions from an interface even if they're tagged that
             # way in the registry.
-            if (regRemoveExtensions.match(extName) != None):
+            if (regRemoveExtensions.match(extName) is not None):
                 self.gen.logMsg('diag', 'Removing extension',
                     extName, '(matches explicitly requested extensions to remove)')
                 include = False
@@ -967,7 +967,7 @@ class Registry:
             # If the extension is to be included, add it to the
             # extension features list.
             if (include):
-                ei.emit = (regEmitExtensions.match(extName) != None)
+                ei.emit = (regEmitExtensions.match(extName) is not None)
                 features.append(ei)
                 if (not ei.emit):
                     self.gen.logMsg('diag', 'NOT tagging extension',
@@ -1053,7 +1053,7 @@ class Registry:
                         badGroup[group] = badGroup[group] +  1
             for param in cmd.findall('param'):
                 pname = param.find('name')
-                if (pname != None):
+                if (pname is not None):
                     pname = pname.text
                 else:
                     pname = type.get('name')


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations