### PR TITLE
build: Fix install target path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ endif()
 
 # --------------------------------------------------------------------------------------------------------------------------------
 
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/registry" DESTINATION ${CMAKE_INSTALL_DATADIR}/vulkan)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${CMAKE_INSTALL_DATADIR}/vulkan)
 
 # uninstall target
 if(NOT TARGET uninstall)


### PR DESCRIPTION
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR when defining
the path for the source files to be installed.