### PR TITLE
Update for Vulkan-Docs 1.1.108 - needs fix for VulkanHppGenerator

### DIFF
--- a/include/vulkan/vulkan.hpp
+++ b/include/vulkan/vulkan.hpp
@@ -56,7 +56,7 @@
 # define VULKAN_HPP_ASSERT   assert
 #endif
 
-static_assert( VK_HEADER_VERSION ==  103 , "Wrong VK_HEADER_VERSION!" );
+static_assert( VK_HEADER_VERSION ==  108 , "Wrong VK_HEADER_VERSION!" );
 
 // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
 // To enable this feature on 32-bit platforms please define VULKAN_HPP_TYPESAFE_CONVERSION
@@ -1089,6 +1089,13 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkResetCommandBuffer( commandBuffer, flags );
     }
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    VkResult vkAcquireFullScreenExclusiveModeEXT( VkDevice device, VkSwapchainKHR swapchain ) const
+    {
+      return ::vkAcquireFullScreenExclusiveModeEXT( device, swapchain );
+    }
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
     VkResult vkAcquireNextImage2KHR( VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex ) const
     {
       return ::vkAcquireNextImage2KHR( device, pAcquireInfo, pImageIndex );
@@ -1556,6 +1563,13 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkGetDeviceGroupPresentCapabilitiesKHR( device, pDeviceGroupPresentCapabilities );
     }
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    VkResult vkGetDeviceGroupSurfacePresentModes2EXT( VkDevice device, const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, VkDeviceGroupPresentModeFlagsKHR* pModes ) const
+    {
+      return ::vkGetDeviceGroupSurfacePresentModes2EXT( device, pSurfaceInfo, pModes );
+    }
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
     VkResult vkGetDeviceGroupSurfacePresentModesKHR( VkDevice device, VkSurfaceKHR surface, VkDeviceGroupPresentModeFlagsKHR* pModes ) const
     {
       return ::vkGetDeviceGroupSurfacePresentModesKHR( device, surface, pModes );
@@ -1817,6 +1831,13 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkRegisterObjectsNVX( device, objectTable, objectCount, ppObjectTableEntries, pObjectIndices );
     }
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    VkResult vkReleaseFullScreenExclusiveModeEXT( VkDevice device, VkSwapchainKHR swapchain ) const
+    {
+      return ::vkReleaseFullScreenExclusiveModeEXT( device, swapchain );
+    }
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
     VkResult vkResetCommandPool( VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags ) const
     {
       return ::vkResetCommandPool( device, commandPool, flags );
@@ -1837,6 +1858,11 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkResetFences( device, fenceCount, pFences );
     }
 
+    void vkResetQueryPoolEXT( VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount ) const
+    {
+      return ::vkResetQueryPoolEXT( device, queryPool, firstQuery, queryCount );
+    }
+
     VkResult vkSetDebugUtilsObjectNameEXT( VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo ) const
     {
       return ::vkSetDebugUtilsObjectNameEXT( device, pNameInfo );
@@ -1855,6 +1881,11 @@ namespace VULKAN_HPP_NAMESPACE
     void vkSetHdrMetadataEXT( VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR* pSwapchains, const VkHdrMetadataEXT* pMetadata ) const
     {
       return ::vkSetHdrMetadataEXT( device, swapchainCount, pSwapchains, pMetadata );
+    }
+
+    void vkSetLocalDimmingAMD( VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable ) const
+    {
+      return ::vkSetLocalDimmingAMD( device, swapChain, localDimmingEnable );
     }
 
     void vkTrimCommandPool( VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags ) const
@@ -1919,6 +1950,11 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkCreateDisplayPlaneSurfaceKHR( instance, pCreateInfo, pAllocator, pSurface );
     }
 
+    VkResult vkCreateHeadlessSurfaceEXT( VkInstance instance, const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface ) const
+    {
+      return ::vkCreateHeadlessSurfaceEXT( instance, pCreateInfo, pAllocator, pSurface );
+    }
+
 #ifdef VK_USE_PLATFORM_IOS_MVK
     VkResult vkCreateIOSSurfaceMVK( VkInstance instance, const VkIOSSurfaceCreateInfoMVK* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface ) const
     {
@@ -1946,6 +1982,13 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkCreateMetalSurfaceEXT( instance, pCreateInfo, pAllocator, pSurface );
     }
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
+
+#ifdef VK_USE_PLATFORM_GGP
+    VkResult vkCreateStreamDescriptorSurfaceGGP( VkInstance instance, const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface ) const
+    {
+      return ::vkCreateStreamDescriptorSurfaceGGP( instance, pCreateInfo, pAllocator, pSurface );
+    }
+#endif /*VK_USE_PLATFORM_GGP*/
 
 #ifdef VK_USE_PLATFORM_VI_NN
     VkResult vkCreateViSurfaceNN( VkInstance instance, const VkViSurfaceCreateInfoNN* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface ) const
@@ -2269,6 +2312,11 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkGetPhysicalDeviceSparseImageFormatProperties2KHR( physicalDevice, pFormatInfo, pPropertyCount, pProperties );
     }
 
+    VkResult vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV( VkPhysicalDevice physicalDevice, uint32_t* pCombinationCount, VkFramebufferMixedSamplesCombinationNV* pCombinations ) const
+    {
+      return ::vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV( physicalDevice, pCombinationCount, pCombinations );
+    }
+
     VkResult vkGetPhysicalDeviceSurfaceCapabilities2EXT( VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilities2EXT* pSurfaceCapabilities ) const
     {
       return ::vkGetPhysicalDeviceSurfaceCapabilities2EXT( physicalDevice, surface, pSurfaceCapabilities );
@@ -2293,6 +2341,13 @@ namespace VULKAN_HPP_NAMESPACE
     {
       return ::vkGetPhysicalDeviceSurfaceFormatsKHR( physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats );
     }
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    VkResult vkGetPhysicalDeviceSurfacePresentModes2EXT( VkPhysicalDevice physicalDevice, const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes ) const
+    {
+      return ::vkGetPhysicalDeviceSurfacePresentModes2EXT( physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes );
+    }
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
     VkResult vkGetPhysicalDeviceSurfacePresentModesKHR( VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes ) const
     {
@@ -2812,7 +2867,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSrgbNonlinear = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
     eDisplayP3NonlinearEXT = VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT,
     eExtendedSrgbLinearEXT = VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT,
-    eDciP3LinearEXT = VK_COLOR_SPACE_DCI_P3_LINEAR_EXT,
+    eDisplayP3LinearEXT = VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT,
     eDciP3NonlinearEXT = VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT,
     eBt709LinearEXT = VK_COLOR_SPACE_BT709_LINEAR_EXT,
     eBt709NonlinearEXT = VK_COLOR_SPACE_BT709_NONLINEAR_EXT,
@@ -2824,7 +2879,9 @@ namespace VULKAN_HPP_NAMESPACE
     eAdobergbNonlinearEXT = VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT,
     ePassThroughEXT = VK_COLOR_SPACE_PASS_THROUGH_EXT,
     eExtendedSrgbNonlinearEXT = VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT,
-    eVkColorspaceSrgbNonlinear = VK_COLORSPACE_SRGB_NONLINEAR_KHR
+    eDisplayNativeAMD = VK_COLOR_SPACE_DISPLAY_NATIVE_AMD,
+    eVkColorspaceSrgbNonlinear = VK_COLORSPACE_SRGB_NONLINEAR_KHR,
+    eDciP3LinearEXT = VK_COLOR_SPACE_DCI_P3_LINEAR_EXT
   };
 
   VULKAN_HPP_INLINE std::string to_string( ColorSpaceKHR value )
@@ -2834,7 +2891,7 @@ namespace VULKAN_HPP_NAMESPACE
       case ColorSpaceKHR::eSrgbNonlinear : return "SrgbNonlinear";
       case ColorSpaceKHR::eDisplayP3NonlinearEXT : return "DisplayP3NonlinearEXT";
       case ColorSpaceKHR::eExtendedSrgbLinearEXT : return "ExtendedSrgbLinearEXT";
-      case ColorSpaceKHR::eDciP3LinearEXT : return "DciP3LinearEXT";
+      case ColorSpaceKHR::eDisplayP3LinearEXT : return "DisplayP3LinearEXT";
       case ColorSpaceKHR::eDciP3NonlinearEXT : return "DciP3NonlinearEXT";
       case ColorSpaceKHR::eBt709LinearEXT : return "Bt709LinearEXT";
       case ColorSpaceKHR::eBt709NonlinearEXT : return "Bt709NonlinearEXT";
@@ -2846,6 +2903,7 @@ namespace VULKAN_HPP_NAMESPACE
       case ColorSpaceKHR::eAdobergbNonlinearEXT : return "AdobergbNonlinearEXT";
       case ColorSpaceKHR::ePassThroughEXT : return "PassThroughEXT";
       case ColorSpaceKHR::eExtendedSrgbNonlinearEXT : return "ExtendedSrgbNonlinearEXT";
+      case ColorSpaceKHR::eDisplayNativeAMD : return "DisplayNativeAMD";
       default: return "invalid";
     }
   }
@@ -3004,6 +3062,22 @@ namespace VULKAN_HPP_NAMESPACE
       case CoverageModulationModeNV::eRgb : return "Rgb";
       case CoverageModulationModeNV::eAlpha : return "Alpha";
       case CoverageModulationModeNV::eRgba : return "Rgba";
+      default: return "invalid";
+    }
+  }
+
+  enum class CoverageReductionModeNV
+  {
+    eMerge = VK_COVERAGE_REDUCTION_MODE_MERGE_NV,
+    eTruncate = VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV
+  };
+
+  VULKAN_HPP_INLINE std::string to_string( CoverageReductionModeNV value )
+  {
+    switch ( value )
+    {
+      case CoverageReductionModeNV::eMerge : return "Merge";
+      case CoverageReductionModeNV::eTruncate : return "Truncate";
       default: return "invalid";
     }
   }
@@ -3226,7 +3300,8 @@ namespace VULKAN_HPP_NAMESPACE
     eImaginationProprietary = VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR,
     eQualcommProprietary = VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR,
     eArmProprietary = VK_DRIVER_ID_ARM_PROPRIETARY_KHR,
-    eGooglePastel = VK_DRIVER_ID_GOOGLE_PASTEL_KHR
+    eGooglePastel = VK_DRIVER_ID_GOOGLE_PASTEL_KHR,
+    eGgpProprietary = VK_DRIVER_ID_GGP_PROPRIETARY_KHR
   };
 
   VULKAN_HPP_INLINE std::string to_string( DriverIdKHR value )
@@ -3243,6 +3318,7 @@ namespace VULKAN_HPP_NAMESPACE
       case DriverIdKHR::eQualcommProprietary : return "QualcommProprietary";
       case DriverIdKHR::eArmProprietary : return "ArmProprietary";
       case DriverIdKHR::eGooglePastel : return "GooglePastel";
+      case DriverIdKHR::eGgpProprietary : return "GgpProprietary";
       default: return "invalid";
     }
   }
@@ -3823,6 +3899,28 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid";
     }
   }
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  enum class FullScreenExclusiveEXT
+  {
+    eDefault = VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT,
+    eAllowed = VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT,
+    eDisallowed = VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT,
+    eApplicationControlled = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT
+  };
+
+  VULKAN_HPP_INLINE std::string to_string( FullScreenExclusiveEXT value )
+  {
+    switch ( value )
+    {
+      case FullScreenExclusiveEXT::eDefault : return "Default";
+      case FullScreenExclusiveEXT::eAllowed : return "Allowed";
+      case FullScreenExclusiveEXT::eDisallowed : return "Disallowed";
+      case FullScreenExclusiveEXT::eApplicationControlled : return "ApplicationControlled";
+      default: return "invalid";
+    }
+  }
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
   enum class GeometryTypeNV
   {
@@ -4439,6 +4537,7 @@ namespace VULKAN_HPP_NAMESPACE
     eErrorFragmentationEXT = VK_ERROR_FRAGMENTATION_EXT,
     eErrorNotPermittedEXT = VK_ERROR_NOT_PERMITTED_EXT,
     eErrorInvalidDeviceAddressEXT = VK_ERROR_INVALID_DEVICE_ADDRESS_EXT,
+    eErrorFullScreenExclusiveModeLostEXT = VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT,
     eErrorOutOfPoolMemoryKHR = VK_ERROR_OUT_OF_POOL_MEMORY_KHR,
     eErrorInvalidExternalHandleKHR = VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR
   };
@@ -4478,6 +4577,7 @@ namespace VULKAN_HPP_NAMESPACE
       case Result::eErrorFragmentationEXT : return "ErrorFragmentationEXT";
       case Result::eErrorNotPermittedEXT : return "ErrorNotPermittedEXT";
       case Result::eErrorInvalidDeviceAddressEXT : return "ErrorInvalidDeviceAddressEXT";
+      case Result::eErrorFullScreenExclusiveModeLostEXT : return "ErrorFullScreenExclusiveModeLostEXT";
       default: return "invalid";
     }
   }
@@ -4788,7 +4888,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRenderPassMultiviewCreateInfo = VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO,
     ePhysicalDeviceMultiviewFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES,
     ePhysicalDeviceMultiviewProperties = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES,
-    ePhysicalDeviceVariablePointerFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES,
+    ePhysicalDeviceVariablePointersFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES,
     eProtectedSubmitInfo = VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO,
     ePhysicalDeviceProtectedMemoryFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES,
     ePhysicalDeviceProtectedMemoryProperties = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES,
@@ -4816,7 +4916,7 @@ namespace VULKAN_HPP_NAMESPACE
     eExternalSemaphoreProperties = VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES,
     ePhysicalDeviceMaintenance3Properties = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES,
     eDescriptorSetLayoutSupport = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT,
-    ePhysicalDeviceShaderDrawParameterFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES,
+    ePhysicalDeviceShaderDrawParametersFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES,
     eSwapchainCreateInfoKHR = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
     ePresentInfoKHR = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
     eDeviceGroupPresentCapabilitiesKHR = VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR,
@@ -4846,6 +4946,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePipelineRasterizationStateStreamCreateInfoEXT = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT,
     eImageViewHandleInfoNVX = VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX,
     eTextureLodGatherFormatPropertiesAMD = VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD,
+    eStreamDescriptorSurfaceCreateInfoGGP = VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP,
     ePhysicalDeviceCornerSampledImageFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV,
     eExternalMemoryImageCreateInfoNV = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV,
     eExportMemoryAllocateInfoNV = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV,
@@ -4993,6 +5094,8 @@ namespace VULKAN_HPP_NAMESPACE
     ePhysicalDeviceVertexAttributeDivisorPropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT,
     ePipelineVertexInputDivisorStateCreateInfoEXT = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT,
     ePhysicalDeviceVertexAttributeDivisorFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT,
+    ePresentFrameTokenGGP = VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP,
+    ePipelineCreationFeedbackCreateInfoEXT = VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT,
     ePhysicalDeviceDriverPropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR,
     ePhysicalDeviceFloatControlsPropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR,
     ePhysicalDeviceDepthStencilResolvePropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES_KHR,
@@ -5008,6 +5111,8 @@ namespace VULKAN_HPP_NAMESPACE
     eQueueFamilyCheckpointPropertiesNV = VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV,
     ePhysicalDeviceVulkanMemoryModelFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR,
     ePhysicalDevicePciBusInfoPropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT,
+    eDisplayNativeHdrSurfaceCapabilitiesAMD = VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD,
+    eSwapchainDisplayNativeHdrCreateInfoAMD = VK_STRUCTURE_TYPE_SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD,
     eImagepipeSurfaceCreateInfoFUCHSIA = VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA,
     eMetalSurfaceCreateInfoEXT = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT,
     ePhysicalDeviceFragmentDensityMapFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT,
@@ -5017,8 +5122,9 @@ namespace VULKAN_HPP_NAMESPACE
     ePhysicalDeviceMemoryBudgetPropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT,
     ePhysicalDeviceMemoryPriorityFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT,
     eMemoryPriorityAllocateInfoEXT = VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT,
+    eSurfaceProtectedCapabilitiesKHR = VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR,
     ePhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV,
-    ePhysicalDeviceBufferAddressFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT,
+    ePhysicalDeviceBufferDeviceAddressFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT,
     eBufferDeviceAddressInfoEXT = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_EXT,
     eBufferDeviceAddressCreateInfoEXT = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT,
     eImageStencilUsageCreateInfoEXT = VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO_EXT,
@@ -5026,7 +5132,18 @@ namespace VULKAN_HPP_NAMESPACE
     ePhysicalDeviceCooperativeMatrixFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV,
     eCooperativeMatrixPropertiesNV = VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV,
     ePhysicalDeviceCooperativeMatrixPropertiesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV,
+    ePhysicalDeviceCoverageReductionModeFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV,
+    ePipelineCoverageReductionStateCreateInfoNV = VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV,
+    eFramebufferMixedSamplesCombinationNV = VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV,
     ePhysicalDeviceYcbcrImageArraysFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT,
+    ePhysicalDeviceUniformBufferStandardLayoutFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR,
+    eSurfaceFullScreenExclusiveInfoEXT = VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT,
+    eSurfaceCapabilitiesFullScreenExclusiveEXT = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT,
+    eSurfaceFullScreenExclusiveWin32InfoEXT = VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT,
+    eHeadlessSurfaceCreateInfoEXT = VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT,
+    ePhysicalDeviceHostQueryResetFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT,
+    ePhysicalDeviceVariablePointerFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES,
+    ePhysicalDeviceShaderDrawParameterFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES,
     eDebugReportCreateInfoEXT = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT,
     eRenderPassMultiviewCreateInfoKHR = VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO_KHR,
     ePhysicalDeviceMultiviewFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR,
@@ -5070,6 +5187,7 @@ namespace VULKAN_HPP_NAMESPACE
     eImageViewUsageCreateInfoKHR = VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO_KHR,
     ePipelineTessellationDomainOriginStateCreateInfoKHR = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO_KHR,
     ePhysicalDeviceVariablePointerFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR,
+    ePhysicalDeviceVariablePointersFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR,
     eMemoryDedicatedRequirementsKHR = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR,
     eMemoryDedicatedAllocateInfoKHR = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
     eBufferMemoryRequirementsInfo2KHR = VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR,
@@ -5086,7 +5204,8 @@ namespace VULKAN_HPP_NAMESPACE
     eBindBufferMemoryInfoKHR = VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO_KHR,
     eBindImageMemoryInfoKHR = VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHR,
     ePhysicalDeviceMaintenance3PropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES_KHR,
-    eDescriptorSetLayoutSupportKHR = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT_KHR
+    eDescriptorSetLayoutSupportKHR = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT_KHR,
+    ePhysicalDeviceBufferAddressFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT
   };
 
   VULKAN_HPP_INLINE std::string to_string( StructureType value )
@@ -5178,7 +5297,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eRenderPassMultiviewCreateInfo : return "RenderPassMultiviewCreateInfo";
       case StructureType::ePhysicalDeviceMultiviewFeatures : return "PhysicalDeviceMultiviewFeatures";
       case StructureType::ePhysicalDeviceMultiviewProperties : return "PhysicalDeviceMultiviewProperties";
-      case StructureType::ePhysicalDeviceVariablePointerFeatures : return "PhysicalDeviceVariablePointerFeatures";
+      case StructureType::ePhysicalDeviceVariablePointersFeatures : return "PhysicalDeviceVariablePointersFeatures";
       case StructureType::eProtectedSubmitInfo : return "ProtectedSubmitInfo";
       case StructureType::ePhysicalDeviceProtectedMemoryFeatures : return "PhysicalDeviceProtectedMemoryFeatures";
       case StructureType::ePhysicalDeviceProtectedMemoryProperties : return "PhysicalDeviceProtectedMemoryProperties";
@@ -5206,7 +5325,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eExternalSemaphoreProperties : return "ExternalSemaphoreProperties";
       case StructureType::ePhysicalDeviceMaintenance3Properties : return "PhysicalDeviceMaintenance3Properties";
       case StructureType::eDescriptorSetLayoutSupport : return "DescriptorSetLayoutSupport";
-      case StructureType::ePhysicalDeviceShaderDrawParameterFeatures : return "PhysicalDeviceShaderDrawParameterFeatures";
+      case StructureType::ePhysicalDeviceShaderDrawParametersFeatures : return "PhysicalDeviceShaderDrawParametersFeatures";
       case StructureType::eSwapchainCreateInfoKHR : return "SwapchainCreateInfoKHR";
       case StructureType::ePresentInfoKHR : return "PresentInfoKHR";
       case StructureType::eDeviceGroupPresentCapabilitiesKHR : return "DeviceGroupPresentCapabilitiesKHR";
@@ -5236,6 +5355,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePipelineRasterizationStateStreamCreateInfoEXT : return "PipelineRasterizationStateStreamCreateInfoEXT";
       case StructureType::eImageViewHandleInfoNVX : return "ImageViewHandleInfoNVX";
       case StructureType::eTextureLodGatherFormatPropertiesAMD : return "TextureLodGatherFormatPropertiesAMD";
+      case StructureType::eStreamDescriptorSurfaceCreateInfoGGP : return "StreamDescriptorSurfaceCreateInfoGGP";
       case StructureType::ePhysicalDeviceCornerSampledImageFeaturesNV : return "PhysicalDeviceCornerSampledImageFeaturesNV";
       case StructureType::eExternalMemoryImageCreateInfoNV : return "ExternalMemoryImageCreateInfoNV";
       case StructureType::eExportMemoryAllocateInfoNV : return "ExportMemoryAllocateInfoNV";
@@ -5383,6 +5503,8 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDeviceVertexAttributeDivisorPropertiesEXT : return "PhysicalDeviceVertexAttributeDivisorPropertiesEXT";
       case StructureType::ePipelineVertexInputDivisorStateCreateInfoEXT : return "PipelineVertexInputDivisorStateCreateInfoEXT";
       case StructureType::ePhysicalDeviceVertexAttributeDivisorFeaturesEXT : return "PhysicalDeviceVertexAttributeDivisorFeaturesEXT";
+      case StructureType::ePresentFrameTokenGGP : return "PresentFrameTokenGGP";
+      case StructureType::ePipelineCreationFeedbackCreateInfoEXT : return "PipelineCreationFeedbackCreateInfoEXT";
       case StructureType::ePhysicalDeviceDriverPropertiesKHR : return "PhysicalDeviceDriverPropertiesKHR";
       case StructureType::ePhysicalDeviceFloatControlsPropertiesKHR : return "PhysicalDeviceFloatControlsPropertiesKHR";
       case StructureType::ePhysicalDeviceDepthStencilResolvePropertiesKHR : return "PhysicalDeviceDepthStencilResolvePropertiesKHR";
@@ -5398,6 +5520,8 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eQueueFamilyCheckpointPropertiesNV : return "QueueFamilyCheckpointPropertiesNV";
       case StructureType::ePhysicalDeviceVulkanMemoryModelFeaturesKHR : return "PhysicalDeviceVulkanMemoryModelFeaturesKHR";
       case StructureType::ePhysicalDevicePciBusInfoPropertiesEXT : return "PhysicalDevicePciBusInfoPropertiesEXT";
+      case StructureType::eDisplayNativeHdrSurfaceCapabilitiesAMD : return "DisplayNativeHdrSurfaceCapabilitiesAMD";
+      case StructureType::eSwapchainDisplayNativeHdrCreateInfoAMD : return "SwapchainDisplayNativeHdrCreateInfoAMD";
       case StructureType::eImagepipeSurfaceCreateInfoFUCHSIA : return "ImagepipeSurfaceCreateInfoFUCHSIA";
       case StructureType::eMetalSurfaceCreateInfoEXT : return "MetalSurfaceCreateInfoEXT";
       case StructureType::ePhysicalDeviceFragmentDensityMapFeaturesEXT : return "PhysicalDeviceFragmentDensityMapFeaturesEXT";
@@ -5407,8 +5531,9 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDeviceMemoryBudgetPropertiesEXT : return "PhysicalDeviceMemoryBudgetPropertiesEXT";
       case StructureType::ePhysicalDeviceMemoryPriorityFeaturesEXT : return "PhysicalDeviceMemoryPriorityFeaturesEXT";
       case StructureType::eMemoryPriorityAllocateInfoEXT : return "MemoryPriorityAllocateInfoEXT";
+      case StructureType::eSurfaceProtectedCapabilitiesKHR : return "SurfaceProtectedCapabilitiesKHR";
       case StructureType::ePhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV : return "PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV";
-      case StructureType::ePhysicalDeviceBufferAddressFeaturesEXT : return "PhysicalDeviceBufferAddressFeaturesEXT";
+      case StructureType::ePhysicalDeviceBufferDeviceAddressFeaturesEXT : return "PhysicalDeviceBufferDeviceAddressFeaturesEXT";
       case StructureType::eBufferDeviceAddressInfoEXT : return "BufferDeviceAddressInfoEXT";
       case StructureType::eBufferDeviceAddressCreateInfoEXT : return "BufferDeviceAddressCreateInfoEXT";
       case StructureType::eImageStencilUsageCreateInfoEXT : return "ImageStencilUsageCreateInfoEXT";
@@ -5416,7 +5541,16 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDeviceCooperativeMatrixFeaturesNV : return "PhysicalDeviceCooperativeMatrixFeaturesNV";
       case StructureType::eCooperativeMatrixPropertiesNV : return "CooperativeMatrixPropertiesNV";
       case StructureType::ePhysicalDeviceCooperativeMatrixPropertiesNV : return "PhysicalDeviceCooperativeMatrixPropertiesNV";
+      case StructureType::ePhysicalDeviceCoverageReductionModeFeaturesNV : return "PhysicalDeviceCoverageReductionModeFeaturesNV";
+      case StructureType::ePipelineCoverageReductionStateCreateInfoNV : return "PipelineCoverageReductionStateCreateInfoNV";
+      case StructureType::eFramebufferMixedSamplesCombinationNV : return "FramebufferMixedSamplesCombinationNV";
       case StructureType::ePhysicalDeviceYcbcrImageArraysFeaturesEXT : return "PhysicalDeviceYcbcrImageArraysFeaturesEXT";
+      case StructureType::ePhysicalDeviceUniformBufferStandardLayoutFeaturesKHR : return "PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR";
+      case StructureType::eSurfaceFullScreenExclusiveInfoEXT : return "SurfaceFullScreenExclusiveInfoEXT";
+      case StructureType::eSurfaceCapabilitiesFullScreenExclusiveEXT : return "SurfaceCapabilitiesFullScreenExclusiveEXT";
+      case StructureType::eSurfaceFullScreenExclusiveWin32InfoEXT : return "SurfaceFullScreenExclusiveWin32InfoEXT";
+      case StructureType::eHeadlessSurfaceCreateInfoEXT : return "HeadlessSurfaceCreateInfoEXT";
+      case StructureType::ePhysicalDeviceHostQueryResetFeaturesEXT : return "PhysicalDeviceHostQueryResetFeaturesEXT";
       default: return "invalid";
     }
   }
@@ -7826,6 +7960,21 @@ namespace VULKAN_HPP_NAMESPACE
     return "{ " + result.substr(0, result.size() - 3) + " }";
   }
 
+  enum class HeadlessSurfaceCreateFlagBitsEXT
+  {};
+
+  VULKAN_HPP_INLINE std::string to_string( HeadlessSurfaceCreateFlagBitsEXT )
+  {
+    return "(void)";
+  }
+
+  using HeadlessSurfaceCreateFlagsEXT = Flags<HeadlessSurfaceCreateFlagBitsEXT, VkHeadlessSurfaceCreateFlagsEXT>;
+
+  VULKAN_HPP_INLINE std::string to_string( HeadlessSurfaceCreateFlagsEXT  )
+  {
+    return "{}";
+  }
+
 #ifdef VK_USE_PLATFORM_IOS_MVK
   enum class IOSSurfaceCreateFlagBitsMVK
   {};
@@ -8556,6 +8705,21 @@ namespace VULKAN_HPP_NAMESPACE
     return "{}";
   }
 
+  enum class PipelineCoverageReductionStateCreateFlagBitsNV
+  {};
+
+  VULKAN_HPP_INLINE std::string to_string( PipelineCoverageReductionStateCreateFlagBitsNV )
+  {
+    return "(void)";
+  }
+
+  using PipelineCoverageReductionStateCreateFlagsNV = Flags<PipelineCoverageReductionStateCreateFlagBitsNV, VkPipelineCoverageReductionStateCreateFlagsNV>;
+
+  VULKAN_HPP_INLINE std::string to_string( PipelineCoverageReductionStateCreateFlagsNV  )
+  {
+    return "{}";
+  }
+
   enum class PipelineCoverageToColorStateCreateFlagBitsNV
   {};
 
@@ -8628,6 +8792,55 @@ namespace VULKAN_HPP_NAMESPACE
     if ( value & PipelineCreateFlagBits::eViewIndexFromDeviceIndex ) result += "ViewIndexFromDeviceIndex | ";
     if ( value & PipelineCreateFlagBits::eDispatchBase ) result += "DispatchBase | ";
     if ( value & PipelineCreateFlagBits::eDeferCompileNV ) result += "DeferCompileNV | ";
+    return "{ " + result.substr(0, result.size() - 3) + " }";
+  }
+
+  enum class PipelineCreationFeedbackFlagBitsEXT
+  {
+    eValid = VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT_EXT,
+    eApplicationPipelineCacheHit = VK_PIPELINE_CREATION_FEEDBACK_APPLICATION_PIPELINE_CACHE_HIT_BIT_EXT,
+    eBasePipelineAcceleration = VK_PIPELINE_CREATION_FEEDBACK_BASE_PIPELINE_ACCELERATION_BIT_EXT
+  };
+
+  VULKAN_HPP_INLINE std::string to_string( PipelineCreationFeedbackFlagBitsEXT value )
+  {
+    switch ( value )
+    {
+      case PipelineCreationFeedbackFlagBitsEXT::eValid : return "Valid";
+      case PipelineCreationFeedbackFlagBitsEXT::eApplicationPipelineCacheHit : return "ApplicationPipelineCacheHit";
+      case PipelineCreationFeedbackFlagBitsEXT::eBasePipelineAcceleration : return "BasePipelineAcceleration";
+      default: return "invalid";
+    }
+  }
+
+  using PipelineCreationFeedbackFlagsEXT = Flags<PipelineCreationFeedbackFlagBitsEXT, VkPipelineCreationFeedbackFlagsEXT>;
+
+  VULKAN_HPP_INLINE PipelineCreationFeedbackFlagsEXT operator|( PipelineCreationFeedbackFlagBitsEXT bit0, PipelineCreationFeedbackFlagBitsEXT bit1 )
+  {
+    return PipelineCreationFeedbackFlagsEXT( bit0 ) | bit1;
+  }
+
+  VULKAN_HPP_INLINE PipelineCreationFeedbackFlagsEXT operator~( PipelineCreationFeedbackFlagBitsEXT bits )
+  {
+    return ~( PipelineCreationFeedbackFlagsEXT( bits ) );
+  }
+
+  template <> struct FlagTraits<PipelineCreationFeedbackFlagBitsEXT>
+  {
+    enum
+    {
+      allFlags = VkFlags(PipelineCreationFeedbackFlagBitsEXT::eValid) | VkFlags(PipelineCreationFeedbackFlagBitsEXT::eApplicationPipelineCacheHit) | VkFlags(PipelineCreationFeedbackFlagBitsEXT::eBasePipelineAcceleration)
+    };
+  };
+
+  VULKAN_HPP_INLINE std::string to_string( PipelineCreationFeedbackFlagsEXT value  )
+  {
+    if ( !value ) return "{}";
+    std::string result;
+
+    if ( value & PipelineCreationFeedbackFlagBitsEXT::eValid ) result += "Valid | ";
+    if ( value & PipelineCreationFeedbackFlagBitsEXT::eApplicationPipelineCacheHit ) result += "ApplicationPipelineCacheHit | ";
+    if ( value & PipelineCreationFeedbackFlagBitsEXT::eBasePipelineAcceleration ) result += "BasePipelineAcceleration | ";
     return "{ " + result.substr(0, result.size() - 3) + " }";
   }
 
@@ -9694,6 +9907,23 @@ namespace VULKAN_HPP_NAMESPACE
     return "{ " + result.substr(0, result.size() - 3) + " }";
   }
 
+#ifdef VK_USE_PLATFORM_GGP
+  enum class StreamDescriptorSurfaceCreateFlagBitsGGP
+  {};
+
+  VULKAN_HPP_INLINE std::string to_string( StreamDescriptorSurfaceCreateFlagBitsGGP )
+  {
+    return "(void)";
+  }
+
+  using StreamDescriptorSurfaceCreateFlagsGGP = Flags<StreamDescriptorSurfaceCreateFlagBitsGGP, VkStreamDescriptorSurfaceCreateFlagsGGP>;
+
+  VULKAN_HPP_INLINE std::string to_string( StreamDescriptorSurfaceCreateFlagsGGP  )
+  {
+    return "{}";
+  }
+#endif /*VK_USE_PLATFORM_GGP*/
+
   enum class SubgroupFeatureFlagBits
   {
     eBasic = VK_SUBGROUP_FEATURE_BASIC_BIT,
@@ -10364,6 +10594,15 @@ namespace VULKAN_HPP_NAMESPACE
       : SystemError( make_error_code( Result::eErrorInvalidDeviceAddressEXT ), message ) {}
   };
 
+  class FullScreenExclusiveModeLostEXTError : public SystemError
+  {
+  public:
+    FullScreenExclusiveModeLostEXTError( std::string const& message )
+      : SystemError( make_error_code( Result::eErrorFullScreenExclusiveModeLostEXT ), message ) {}
+    FullScreenExclusiveModeLostEXTError( char const * message )
+      : SystemError( make_error_code( Result::eErrorFullScreenExclusiveModeLostEXT ), message ) {}
+  };
+
 
   VULKAN_HPP_INLINE void throwResultException( Result result, char const * message )
   {
@@ -10393,6 +10632,7 @@ namespace VULKAN_HPP_NAMESPACE
       case Result::eErrorFragmentationEXT: throw FragmentationEXTError( message );
       case Result::eErrorNotPermittedEXT: throw NotPermittedEXTError( message );
       case Result::eErrorInvalidDeviceAddressEXT: throw InvalidDeviceAddressEXTError( message );
+      case Result::eErrorFullScreenExclusiveModeLostEXT: throw FullScreenExclusiveModeLostEXTError( message );
       default: throw SystemError( make_error_code( result ) );
     }
   }
@@ -10644,6 +10884,7 @@ namespace VULKAN_HPP_NAMESPACE
   struct DisplayModeParametersKHR;
   struct DisplayModeProperties2KHR;
   struct DisplayModePropertiesKHR;
+  struct DisplayNativeHdrSurfaceCapabilitiesAMD;
   struct DisplayPlaneCapabilities2KHR;
   struct DisplayPlaneCapabilitiesKHR;
   struct DisplayPlaneInfo2KHR;
@@ -10711,12 +10952,14 @@ namespace VULKAN_HPP_NAMESPACE
   struct FormatProperties2;
   using FormatProperties2KHR = FormatProperties2;
   struct FramebufferCreateInfo;
+  struct FramebufferMixedSamplesCombinationNV;
   struct GeometryAABBNV;
   struct GeometryDataNV;
   struct GeometryNV;
   struct GeometryTrianglesNV;
   struct GraphicsPipelineCreateInfo;
   struct HdrMetadataEXT;
+  struct HeadlessSurfaceCreateInfoEXT;
 #ifdef VK_USE_PLATFORM_IOS_MVK
   struct IOSSurfaceCreateInfoMVK;
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
@@ -10827,13 +11070,15 @@ namespace VULKAN_HPP_NAMESPACE
   struct PhysicalDeviceASTCDecodeFeaturesEXT;
   struct PhysicalDeviceBlendOperationAdvancedFeaturesEXT;
   struct PhysicalDeviceBlendOperationAdvancedPropertiesEXT;
-  struct PhysicalDeviceBufferAddressFeaturesEXT;
+  struct PhysicalDeviceBufferDeviceAddressFeaturesEXT;
+  using PhysicalDeviceBufferAddressFeaturesEXT = PhysicalDeviceBufferDeviceAddressFeaturesEXT;
   struct PhysicalDeviceComputeShaderDerivativesFeaturesNV;
   struct PhysicalDeviceConditionalRenderingFeaturesEXT;
   struct PhysicalDeviceConservativeRasterizationPropertiesEXT;
   struct PhysicalDeviceCooperativeMatrixFeaturesNV;
   struct PhysicalDeviceCooperativeMatrixPropertiesNV;
   struct PhysicalDeviceCornerSampledImageFeaturesNV;
+  struct PhysicalDeviceCoverageReductionModeFeaturesNV;
   struct PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV;
   struct PhysicalDeviceDepthClipEnableFeaturesEXT;
   struct PhysicalDeviceDepthStencilResolvePropertiesKHR;
@@ -10861,6 +11106,7 @@ namespace VULKAN_HPP_NAMESPACE
   struct PhysicalDeviceFragmentShaderBarycentricFeaturesNV;
   struct PhysicalDeviceGroupProperties;
   using PhysicalDeviceGroupPropertiesKHR = PhysicalDeviceGroupProperties;
+  struct PhysicalDeviceHostQueryResetFeaturesEXT;
   struct PhysicalDeviceIDProperties;
   using PhysicalDeviceIDPropertiesKHR = PhysicalDeviceIDProperties;
   struct PhysicalDeviceImageDrmFormatModifierInfoEXT;
@@ -10902,7 +11148,8 @@ namespace VULKAN_HPP_NAMESPACE
   struct PhysicalDeviceScalarBlockLayoutFeaturesEXT;
   struct PhysicalDeviceShaderAtomicInt64FeaturesKHR;
   struct PhysicalDeviceShaderCorePropertiesAMD;
-  struct PhysicalDeviceShaderDrawParameterFeatures;
+  struct PhysicalDeviceShaderDrawParametersFeatures;
+  using PhysicalDeviceShaderDrawParameterFeatures = PhysicalDeviceShaderDrawParametersFeatures;
   struct PhysicalDeviceShaderImageFootprintFeaturesNV;
   struct PhysicalDeviceShadingRateImageFeaturesNV;
   struct PhysicalDeviceShadingRateImagePropertiesNV;
@@ -10913,8 +11160,11 @@ namespace VULKAN_HPP_NAMESPACE
   struct PhysicalDeviceSurfaceInfo2KHR;
   struct PhysicalDeviceTransformFeedbackFeaturesEXT;
   struct PhysicalDeviceTransformFeedbackPropertiesEXT;
-  struct PhysicalDeviceVariablePointerFeatures;
-  using PhysicalDeviceVariablePointerFeaturesKHR = PhysicalDeviceVariablePointerFeatures;
+  struct PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR;
+  struct PhysicalDeviceVariablePointersFeatures;
+  using PhysicalDeviceVariablePointersFeaturesKHR = PhysicalDeviceVariablePointersFeatures;
+  using PhysicalDeviceVariablePointerFeaturesKHR = PhysicalDeviceVariablePointersFeatures;
+  using PhysicalDeviceVariablePointerFeatures = PhysicalDeviceVariablePointersFeatures;
   struct PhysicalDeviceVertexAttributeDivisorFeaturesEXT;
   struct PhysicalDeviceVertexAttributeDivisorPropertiesEXT;
   struct PhysicalDeviceVulkanMemoryModelFeaturesKHR;
@@ -10924,7 +11174,10 @@ namespace VULKAN_HPP_NAMESPACE
   struct PipelineColorBlendAttachmentState;
   struct PipelineColorBlendStateCreateInfo;
   struct PipelineCoverageModulationStateCreateInfoNV;
+  struct PipelineCoverageReductionStateCreateInfoNV;
   struct PipelineCoverageToColorStateCreateInfoNV;
+  struct PipelineCreationFeedbackCreateInfoEXT;
+  struct PipelineCreationFeedbackEXT;
   struct PipelineDepthStencilStateCreateInfo;
   struct PipelineDiscardRectangleStateCreateInfoEXT;
   struct PipelineDynamicStateCreateInfo;
@@ -10950,6 +11203,9 @@ namespace VULKAN_HPP_NAMESPACE
   struct PipelineViewportStateCreateInfo;
   struct PipelineViewportSwizzleStateCreateInfoNV;
   struct PipelineViewportWScalingStateCreateInfoNV;
+#ifdef VK_USE_PLATFORM_GGP
+  struct PresentFrameTokenGGP;
+#endif /*VK_USE_PLATFORM_GGP*/
   struct PresentInfoKHR;
   struct PresentRegionKHR;
   struct PresentRegionsKHR;
@@ -11011,6 +11267,9 @@ namespace VULKAN_HPP_NAMESPACE
   struct SpecializationInfo;
   struct SpecializationMapEntry;
   struct StencilOpState;
+#ifdef VK_USE_PLATFORM_GGP
+  struct StreamDescriptorSurfaceCreateInfoGGP;
+#endif /*VK_USE_PLATFORM_GGP*/
   struct SubmitInfo;
   struct SubpassBeginInfoKHR;
   struct SubpassDependency;
@@ -11023,11 +11282,22 @@ namespace VULKAN_HPP_NAMESPACE
   struct SubresourceLayout;
   struct SurfaceCapabilities2EXT;
   struct SurfaceCapabilities2KHR;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  struct SurfaceCapabilitiesFullScreenExclusiveEXT;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
   struct SurfaceCapabilitiesKHR;
   struct SurfaceFormat2KHR;
   struct SurfaceFormatKHR;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  struct SurfaceFullScreenExclusiveInfoEXT;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  struct SurfaceFullScreenExclusiveWin32InfoEXT;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+  struct SurfaceProtectedCapabilitiesKHR;
   struct SwapchainCounterCreateInfoEXT;
   struct SwapchainCreateInfoKHR;
+  struct SwapchainDisplayNativeHdrCreateInfoAMD;
   struct TextureLODGatherFormatPropertiesAMD;
   struct ValidationCacheCreateInfoEXT;
   struct ValidationFeaturesEXT;
@@ -13791,6 +14061,16 @@ namespace VULKAN_HPP_NAMESPACE
       return m_device < rhs.m_device;
     }
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template<typename Dispatch = DispatchLoaderStatic>
+    Result acquireFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d = Dispatch() ) const;
+#else
+    template<typename Dispatch = DispatchLoaderStatic>
+    ResultValueType<void>::type acquireFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d = Dispatch() ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
     template<typename Dispatch = DispatchLoaderStatic>
     Result acquireNextImage2KHR( const AcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -14832,6 +15112,15 @@ namespace VULKAN_HPP_NAMESPACE
     ResultValueType<DeviceGroupPresentCapabilitiesKHR>::type getGroupPresentCapabilitiesKHR(Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    template<typename Dispatch = DispatchLoaderStatic>
+    Result getGroupSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, DeviceGroupPresentModeFlagsKHR* pModes, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template<typename Dispatch = DispatchLoaderStatic>
+    ResultValueType<DeviceGroupPresentModeFlagsKHR>::type getGroupSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Dispatch const &d = Dispatch() ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
     template<typename Dispatch = DispatchLoaderStatic>
     Result getGroupSurfacePresentModesKHR( SurfaceKHR surface, DeviceGroupPresentModeFlagsKHR* pModes, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -15199,6 +15488,16 @@ namespace VULKAN_HPP_NAMESPACE
     ResultValueType<void>::type registerObjectsNVX( ObjectTableNVX objectTable, ArrayProxy<const ObjectTableEntryNVX* const> pObjectTableEntries, ArrayProxy<const uint32_t> objectIndices, Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template<typename Dispatch = DispatchLoaderStatic>
+    Result releaseFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d = Dispatch() ) const;
+#else
+    template<typename Dispatch = DispatchLoaderStatic>
+    ResultValueType<void>::type releaseFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d = Dispatch() ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
 #ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template<typename Dispatch = DispatchLoaderStatic>
     Result resetCommandPool( CommandPool commandPool, CommandPoolResetFlags flags, Dispatch const &d = Dispatch() ) const;
@@ -15231,6 +15530,9 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     template<typename Dispatch = DispatchLoaderStatic>
+    void resetQueryPoolEXT( QueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, Dispatch const &d = Dispatch() ) const;
+
+    template<typename Dispatch = DispatchLoaderStatic>
     Result setDebugUtilsObjectNameEXT( const DebugUtilsObjectNameInfoEXT* pNameInfo, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template<typename Dispatch = DispatchLoaderStatic>
@@ -15258,6 +15560,9 @@ namespace VULKAN_HPP_NAMESPACE
     template<typename Dispatch = DispatchLoaderStatic>
     void setHdrMetadataEXT( ArrayProxy<const SwapchainKHR> swapchains, ArrayProxy<const HdrMetadataEXT> metadata, Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+    template<typename Dispatch = DispatchLoaderStatic>
+    void setLocalDimmingAMD( SwapchainKHR swapChain, Bool32 localDimmingEnable, Dispatch const &d = Dispatch() ) const;
 
     template<typename Dispatch = DispatchLoaderStatic>
     void trimCommandPool( CommandPool commandPool, CommandPoolTrimFlags flags = CommandPoolTrimFlags(), Dispatch const &d = Dispatch() ) const;
@@ -15828,6 +16133,15 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     template<typename Dispatch = DispatchLoaderStatic>
+    Result getSupportedFramebufferMixedSamplesCombinationsNV( uint32_t* pCombinationCount, FramebufferMixedSamplesCombinationNV* pCombinations, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template<typename Allocator = std::allocator<FramebufferMixedSamplesCombinationNV>, typename Dispatch = DispatchLoaderStatic>
+    typename ResultValueType<std::vector<FramebufferMixedSamplesCombinationNV,Allocator>>::type getSupportedFramebufferMixedSamplesCombinationsNV(Dispatch const &d = Dispatch() ) const;
+    template<typename Allocator = std::allocator<FramebufferMixedSamplesCombinationNV>, typename Dispatch = DispatchLoaderStatic>
+    typename ResultValueType<std::vector<FramebufferMixedSamplesCombinationNV,Allocator>>::type getSupportedFramebufferMixedSamplesCombinationsNV(Allocator const& vectorAllocator, Dispatch const &d ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+    template<typename Dispatch = DispatchLoaderStatic>
     Result getSurfaceCapabilities2EXT( SurfaceKHR surface, SurfaceCapabilities2EXT* pSurfaceCapabilities, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template<typename Dispatch = DispatchLoaderStatic>
@@ -15867,6 +16181,17 @@ namespace VULKAN_HPP_NAMESPACE
     template<typename Allocator = std::allocator<SurfaceFormatKHR>, typename Dispatch = DispatchLoaderStatic>
     typename ResultValueType<std::vector<SurfaceFormatKHR,Allocator>>::type getSurfaceFormatsKHR( SurfaceKHR surface, Allocator const& vectorAllocator, Dispatch const &d ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    template<typename Dispatch = DispatchLoaderStatic>
+    Result getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, uint32_t* pPresentModeCount, PresentModeKHR* pPresentModes, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template<typename Allocator = std::allocator<PresentModeKHR>, typename Dispatch = DispatchLoaderStatic>
+    typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Dispatch const &d = Dispatch() ) const;
+    template<typename Allocator = std::allocator<PresentModeKHR>, typename Dispatch = DispatchLoaderStatic>
+    typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Allocator const& vectorAllocator, Dispatch const &d ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
     template<typename Dispatch = DispatchLoaderStatic>
     Result getSurfacePresentModesKHR( SurfaceKHR surface, uint32_t* pPresentModeCount, PresentModeKHR* pPresentModes, Dispatch const &d = Dispatch() ) const;
@@ -16053,6 +16378,17 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+    template<typename Dispatch = DispatchLoaderStatic>
+    Result createHeadlessSurfaceEXT( const HeadlessSurfaceCreateInfoEXT* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template<typename Dispatch = DispatchLoaderStatic>
+    ResultValueType<SurfaceKHR>::type createHeadlessSurfaceEXT( const HeadlessSurfaceCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_NO_SMART_HANDLE
+    template<typename Dispatch = DispatchLoaderStatic>
+    typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type createHeadlessSurfaceEXTUnique( const HeadlessSurfaceCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
+#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
 #ifdef VK_USE_PLATFORM_IOS_MVK
     template<typename Dispatch = DispatchLoaderStatic>
     Result createIOSSurfaceMVK( const IOSSurfaceCreateInfoMVK* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d = Dispatch() ) const;
@@ -16104,6 +16440,19 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
+
+#ifdef VK_USE_PLATFORM_GGP
+    template<typename Dispatch = DispatchLoaderStatic>
+    Result createStreamDescriptorSurfaceGGP( const StreamDescriptorSurfaceCreateInfoGGP* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template<typename Dispatch = DispatchLoaderStatic>
+    ResultValueType<SurfaceKHR>::type createStreamDescriptorSurfaceGGP( const StreamDescriptorSurfaceCreateInfoGGP & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
+#ifndef VULKAN_HPP_NO_SMART_HANDLE
+    template<typename Dispatch = DispatchLoaderStatic>
+    typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type createStreamDescriptorSurfaceGGPUnique( const StreamDescriptorSurfaceCreateInfoGGP & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
+#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_GGP*/
 
 #ifdef VK_USE_PLATFORM_VI_NN
     template<typename Dispatch = DispatchLoaderStatic>
@@ -19876,7 +20225,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   struct BufferDeviceAddressCreateInfoEXT
   {
-    BufferDeviceAddressCreateInfoEXT( DeviceSize deviceAddress_ = 0 )
+    BufferDeviceAddressCreateInfoEXT( DeviceAddress deviceAddress_ = 0 )
       : deviceAddress( deviceAddress_ )
     {}
 
@@ -19897,7 +20246,7 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-    BufferDeviceAddressCreateInfoEXT & setDeviceAddress( DeviceSize deviceAddress_ )
+    BufferDeviceAddressCreateInfoEXT & setDeviceAddress( DeviceAddress deviceAddress_ )
     {
       deviceAddress = deviceAddress_;
       return *this;
@@ -19930,7 +20279,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   public:
     const void* pNext = nullptr;
-    DeviceSize deviceAddress;
+    DeviceAddress deviceAddress;
   };
   static_assert( sizeof( BufferDeviceAddressCreateInfoEXT ) == sizeof( VkBufferDeviceAddressCreateInfoEXT ), "struct and wrapper have different size!" );
 
@@ -26639,6 +26988,39 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DisplayModeProperties2KHR ) == sizeof( VkDisplayModeProperties2KHR ), "struct and wrapper have different size!" );
 
+  struct DisplayNativeHdrSurfaceCapabilitiesAMD
+  {
+    operator VkDisplayNativeHdrSurfaceCapabilitiesAMD const&() const
+    {
+      return *reinterpret_cast<const VkDisplayNativeHdrSurfaceCapabilitiesAMD*>( this );
+    }
+
+    operator VkDisplayNativeHdrSurfaceCapabilitiesAMD &()
+    {
+      return *reinterpret_cast<VkDisplayNativeHdrSurfaceCapabilitiesAMD*>( this );
+    }
+
+    bool operator==( DisplayNativeHdrSurfaceCapabilitiesAMD const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( localDimmingSupport == rhs.localDimmingSupport );
+    }
+
+    bool operator!=( DisplayNativeHdrSurfaceCapabilitiesAMD const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eDisplayNativeHdrSurfaceCapabilitiesAMD;
+
+  public:
+    void* pNext = nullptr;
+    Bool32 localDimmingSupport;
+  };
+  static_assert( sizeof( DisplayNativeHdrSurfaceCapabilitiesAMD ) == sizeof( VkDisplayNativeHdrSurfaceCapabilitiesAMD ), "struct and wrapper have different size!" );
+
   struct DisplayPlaneCapabilitiesKHR
   {
     operator VkDisplayPlaneCapabilitiesKHR const&() const
@@ -29016,6 +29398,45 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( FramebufferCreateInfo ) == sizeof( VkFramebufferCreateInfo ), "struct and wrapper have different size!" );
 
+  struct FramebufferMixedSamplesCombinationNV
+  {
+    operator VkFramebufferMixedSamplesCombinationNV const&() const
+    {
+      return *reinterpret_cast<const VkFramebufferMixedSamplesCombinationNV*>( this );
+    }
+
+    operator VkFramebufferMixedSamplesCombinationNV &()
+    {
+      return *reinterpret_cast<VkFramebufferMixedSamplesCombinationNV*>( this );
+    }
+
+    bool operator==( FramebufferMixedSamplesCombinationNV const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( coverageReductionMode == rhs.coverageReductionMode )
+          && ( rasterizationSamples == rhs.rasterizationSamples )
+          && ( depthStencilSamples == rhs.depthStencilSamples )
+          && ( colorSamples == rhs.colorSamples );
+    }
+
+    bool operator!=( FramebufferMixedSamplesCombinationNV const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eFramebufferMixedSamplesCombinationNV;
+
+  public:
+    void* pNext = nullptr;
+    CoverageReductionModeNV coverageReductionMode;
+    SampleCountFlagBits rasterizationSamples;
+    SampleCountFlags depthStencilSamples;
+    SampleCountFlags colorSamples;
+  };
+  static_assert( sizeof( FramebufferMixedSamplesCombinationNV ) == sizeof( VkFramebufferMixedSamplesCombinationNV ), "struct and wrapper have different size!" );
+
   struct VertexInputBindingDescription
   {
     VertexInputBindingDescription( uint32_t binding_ = 0,
@@ -30858,6 +31279,66 @@ namespace VULKAN_HPP_NAMESPACE
     float maxFrameAverageLightLevel;
   };
   static_assert( sizeof( HdrMetadataEXT ) == sizeof( VkHdrMetadataEXT ), "struct and wrapper have different size!" );
+
+  struct HeadlessSurfaceCreateInfoEXT
+  {
+    HeadlessSurfaceCreateInfoEXT( HeadlessSurfaceCreateFlagsEXT flags_ = HeadlessSurfaceCreateFlagsEXT() )
+      : flags( flags_ )
+    {}
+
+    HeadlessSurfaceCreateInfoEXT( VkHeadlessSurfaceCreateInfoEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( HeadlessSurfaceCreateInfoEXT ) );
+    }
+
+    HeadlessSurfaceCreateInfoEXT& operator=( VkHeadlessSurfaceCreateInfoEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( HeadlessSurfaceCreateInfoEXT ) );
+      return *this;
+    }
+
+    HeadlessSurfaceCreateInfoEXT & setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    HeadlessSurfaceCreateInfoEXT & setFlags( HeadlessSurfaceCreateFlagsEXT flags_ )
+    {
+      flags = flags_;
+      return *this;
+    }
+
+    operator VkHeadlessSurfaceCreateInfoEXT const&() const
+    {
+      return *reinterpret_cast<const VkHeadlessSurfaceCreateInfoEXT*>( this );
+    }
+
+    operator VkHeadlessSurfaceCreateInfoEXT &()
+    {
+      return *reinterpret_cast<VkHeadlessSurfaceCreateInfoEXT*>( this );
+    }
+
+    bool operator==( HeadlessSurfaceCreateInfoEXT const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( flags == rhs.flags );
+    }
+
+    bool operator!=( HeadlessSurfaceCreateInfoEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eHeadlessSurfaceCreateInfoEXT;
+
+  public:
+    const void* pNext = nullptr;
+    HeadlessSurfaceCreateFlagsEXT flags;
+  };
+  static_assert( sizeof( HeadlessSurfaceCreateInfoEXT ) == sizeof( VkHeadlessSurfaceCreateInfoEXT ), "struct and wrapper have different size!" );
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
   struct IOSSurfaceCreateInfoMVK
@@ -35724,62 +36205,62 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PhysicalDeviceBlendOperationAdvancedPropertiesEXT ) == sizeof( VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT ), "struct and wrapper have different size!" );
 
-  struct PhysicalDeviceBufferAddressFeaturesEXT
+  struct PhysicalDeviceBufferDeviceAddressFeaturesEXT
   {
-    PhysicalDeviceBufferAddressFeaturesEXT( Bool32 bufferDeviceAddress_ = 0,
-                                            Bool32 bufferDeviceAddressCaptureReplay_ = 0,
-                                            Bool32 bufferDeviceAddressMultiDevice_ = 0 )
+    PhysicalDeviceBufferDeviceAddressFeaturesEXT( Bool32 bufferDeviceAddress_ = 0,
+                                                  Bool32 bufferDeviceAddressCaptureReplay_ = 0,
+                                                  Bool32 bufferDeviceAddressMultiDevice_ = 0 )
       : bufferDeviceAddress( bufferDeviceAddress_ )
       , bufferDeviceAddressCaptureReplay( bufferDeviceAddressCaptureReplay_ )
       , bufferDeviceAddressMultiDevice( bufferDeviceAddressMultiDevice_ )
     {}
 
-    PhysicalDeviceBufferAddressFeaturesEXT( VkPhysicalDeviceBufferAddressFeaturesEXT const & rhs )
+    PhysicalDeviceBufferDeviceAddressFeaturesEXT( VkPhysicalDeviceBufferDeviceAddressFeaturesEXT const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceBufferAddressFeaturesEXT ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceBufferDeviceAddressFeaturesEXT ) );
     }
 
-    PhysicalDeviceBufferAddressFeaturesEXT& operator=( VkPhysicalDeviceBufferAddressFeaturesEXT const & rhs )
+    PhysicalDeviceBufferDeviceAddressFeaturesEXT& operator=( VkPhysicalDeviceBufferDeviceAddressFeaturesEXT const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceBufferAddressFeaturesEXT ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceBufferDeviceAddressFeaturesEXT ) );
       return *this;
     }
 
-    PhysicalDeviceBufferAddressFeaturesEXT & setPNext( void* pNext_ )
+    PhysicalDeviceBufferDeviceAddressFeaturesEXT & setPNext( void* pNext_ )
     {
       pNext = pNext_;
       return *this;
     }
 
-    PhysicalDeviceBufferAddressFeaturesEXT & setBufferDeviceAddress( Bool32 bufferDeviceAddress_ )
+    PhysicalDeviceBufferDeviceAddressFeaturesEXT & setBufferDeviceAddress( Bool32 bufferDeviceAddress_ )
     {
       bufferDeviceAddress = bufferDeviceAddress_;
       return *this;
     }
 
-    PhysicalDeviceBufferAddressFeaturesEXT & setBufferDeviceAddressCaptureReplay( Bool32 bufferDeviceAddressCaptureReplay_ )
+    PhysicalDeviceBufferDeviceAddressFeaturesEXT & setBufferDeviceAddressCaptureReplay( Bool32 bufferDeviceAddressCaptureReplay_ )
     {
       bufferDeviceAddressCaptureReplay = bufferDeviceAddressCaptureReplay_;
       return *this;
     }
 
-    PhysicalDeviceBufferAddressFeaturesEXT & setBufferDeviceAddressMultiDevice( Bool32 bufferDeviceAddressMultiDevice_ )
+    PhysicalDeviceBufferDeviceAddressFeaturesEXT & setBufferDeviceAddressMultiDevice( Bool32 bufferDeviceAddressMultiDevice_ )
     {
       bufferDeviceAddressMultiDevice = bufferDeviceAddressMultiDevice_;
       return *this;
     }
 
-    operator VkPhysicalDeviceBufferAddressFeaturesEXT const&() const
+    operator VkPhysicalDeviceBufferDeviceAddressFeaturesEXT const&() const
     {
-      return *reinterpret_cast<const VkPhysicalDeviceBufferAddressFeaturesEXT*>( this );
+      return *reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>( this );
     }
 
-    operator VkPhysicalDeviceBufferAddressFeaturesEXT &()
+    operator VkPhysicalDeviceBufferDeviceAddressFeaturesEXT &()
     {
-      return *reinterpret_cast<VkPhysicalDeviceBufferAddressFeaturesEXT*>( this );
+      return *reinterpret_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>( this );
     }
 
-    bool operator==( PhysicalDeviceBufferAddressFeaturesEXT const& rhs ) const
+    bool operator==( PhysicalDeviceBufferDeviceAddressFeaturesEXT const& rhs ) const
     {
       return ( sType == rhs.sType )
           && ( pNext == rhs.pNext )
@@ -35788,13 +36269,13 @@ namespace VULKAN_HPP_NAMESPACE
           && ( bufferDeviceAddressMultiDevice == rhs.bufferDeviceAddressMultiDevice );
     }
 
-    bool operator!=( PhysicalDeviceBufferAddressFeaturesEXT const& rhs ) const
+    bool operator!=( PhysicalDeviceBufferDeviceAddressFeaturesEXT const& rhs ) const
     {
       return !operator==( rhs );
     }
 
   private:
-    StructureType sType = StructureType::ePhysicalDeviceBufferAddressFeaturesEXT;
+    StructureType sType = StructureType::ePhysicalDeviceBufferDeviceAddressFeaturesEXT;
 
   public:
     void* pNext = nullptr;
@@ -35802,7 +36283,7 @@ namespace VULKAN_HPP_NAMESPACE
     Bool32 bufferDeviceAddressCaptureReplay;
     Bool32 bufferDeviceAddressMultiDevice;
   };
-  static_assert( sizeof( PhysicalDeviceBufferAddressFeaturesEXT ) == sizeof( VkPhysicalDeviceBufferAddressFeaturesEXT ), "struct and wrapper have different size!" );
+  static_assert( sizeof( PhysicalDeviceBufferDeviceAddressFeaturesEXT ) == sizeof( VkPhysicalDeviceBufferDeviceAddressFeaturesEXT ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceComputeShaderDerivativesFeaturesNV
   {
@@ -36155,6 +36636,66 @@ namespace VULKAN_HPP_NAMESPACE
     Bool32 cornerSampledImage;
   };
   static_assert( sizeof( PhysicalDeviceCornerSampledImageFeaturesNV ) == sizeof( VkPhysicalDeviceCornerSampledImageFeaturesNV ), "struct and wrapper have different size!" );
+
+  struct PhysicalDeviceCoverageReductionModeFeaturesNV
+  {
+    PhysicalDeviceCoverageReductionModeFeaturesNV( Bool32 coverageReductionMode_ = 0 )
+      : coverageReductionMode( coverageReductionMode_ )
+    {}
+
+    PhysicalDeviceCoverageReductionModeFeaturesNV( VkPhysicalDeviceCoverageReductionModeFeaturesNV const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PhysicalDeviceCoverageReductionModeFeaturesNV ) );
+    }
+
+    PhysicalDeviceCoverageReductionModeFeaturesNV& operator=( VkPhysicalDeviceCoverageReductionModeFeaturesNV const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PhysicalDeviceCoverageReductionModeFeaturesNV ) );
+      return *this;
+    }
+
+    PhysicalDeviceCoverageReductionModeFeaturesNV & setPNext( void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PhysicalDeviceCoverageReductionModeFeaturesNV & setCoverageReductionMode( Bool32 coverageReductionMode_ )
+    {
+      coverageReductionMode = coverageReductionMode_;
+      return *this;
+    }
+
+    operator VkPhysicalDeviceCoverageReductionModeFeaturesNV const&() const
+    {
+      return *reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>( this );
+    }
+
+    operator VkPhysicalDeviceCoverageReductionModeFeaturesNV &()
+    {
+      return *reinterpret_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV*>( this );
+    }
+
+    bool operator==( PhysicalDeviceCoverageReductionModeFeaturesNV const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( coverageReductionMode == rhs.coverageReductionMode );
+    }
+
+    bool operator!=( PhysicalDeviceCoverageReductionModeFeaturesNV const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::ePhysicalDeviceCoverageReductionModeFeaturesNV;
+
+  public:
+    void* pNext = nullptr;
+    Bool32 coverageReductionMode;
+  };
+  static_assert( sizeof( PhysicalDeviceCoverageReductionModeFeaturesNV ) == sizeof( VkPhysicalDeviceCoverageReductionModeFeaturesNV ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV
   {
@@ -37432,6 +37973,66 @@ namespace VULKAN_HPP_NAMESPACE
     Bool32 subsetAllocation;
   };
   static_assert( sizeof( PhysicalDeviceGroupProperties ) == sizeof( VkPhysicalDeviceGroupProperties ), "struct and wrapper have different size!" );
+
+  struct PhysicalDeviceHostQueryResetFeaturesEXT
+  {
+    PhysicalDeviceHostQueryResetFeaturesEXT( Bool32 hostQueryReset_ = 0 )
+      : hostQueryReset( hostQueryReset_ )
+    {}
+
+    PhysicalDeviceHostQueryResetFeaturesEXT( VkPhysicalDeviceHostQueryResetFeaturesEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PhysicalDeviceHostQueryResetFeaturesEXT ) );
+    }
+
+    PhysicalDeviceHostQueryResetFeaturesEXT& operator=( VkPhysicalDeviceHostQueryResetFeaturesEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PhysicalDeviceHostQueryResetFeaturesEXT ) );
+      return *this;
+    }
+
+    PhysicalDeviceHostQueryResetFeaturesEXT & setPNext( void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PhysicalDeviceHostQueryResetFeaturesEXT & setHostQueryReset( Bool32 hostQueryReset_ )
+    {
+      hostQueryReset = hostQueryReset_;
+      return *this;
+    }
+
+    operator VkPhysicalDeviceHostQueryResetFeaturesEXT const&() const
+    {
+      return *reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeaturesEXT*>( this );
+    }
+
+    operator VkPhysicalDeviceHostQueryResetFeaturesEXT &()
+    {
+      return *reinterpret_cast<VkPhysicalDeviceHostQueryResetFeaturesEXT*>( this );
+    }
+
+    bool operator==( PhysicalDeviceHostQueryResetFeaturesEXT const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( hostQueryReset == rhs.hostQueryReset );
+    }
+
+    bool operator!=( PhysicalDeviceHostQueryResetFeaturesEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::ePhysicalDeviceHostQueryResetFeaturesEXT;
+
+  public:
+    void* pNext = nullptr;
+    Bool32 hostQueryReset;
+  };
+  static_assert( sizeof( PhysicalDeviceHostQueryResetFeaturesEXT ) == sizeof( VkPhysicalDeviceHostQueryResetFeaturesEXT ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceIDProperties
   {
@@ -39280,65 +39881,65 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PhysicalDeviceShaderCorePropertiesAMD ) == sizeof( VkPhysicalDeviceShaderCorePropertiesAMD ), "struct and wrapper have different size!" );
 
-  struct PhysicalDeviceShaderDrawParameterFeatures
+  struct PhysicalDeviceShaderDrawParametersFeatures
   {
-    PhysicalDeviceShaderDrawParameterFeatures( Bool32 shaderDrawParameters_ = 0 )
+    PhysicalDeviceShaderDrawParametersFeatures( Bool32 shaderDrawParameters_ = 0 )
       : shaderDrawParameters( shaderDrawParameters_ )
     {}
 
-    PhysicalDeviceShaderDrawParameterFeatures( VkPhysicalDeviceShaderDrawParameterFeatures const & rhs )
+    PhysicalDeviceShaderDrawParametersFeatures( VkPhysicalDeviceShaderDrawParametersFeatures const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderDrawParameterFeatures ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderDrawParametersFeatures ) );
     }
 
-    PhysicalDeviceShaderDrawParameterFeatures& operator=( VkPhysicalDeviceShaderDrawParameterFeatures const & rhs )
+    PhysicalDeviceShaderDrawParametersFeatures& operator=( VkPhysicalDeviceShaderDrawParametersFeatures const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderDrawParameterFeatures ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderDrawParametersFeatures ) );
       return *this;
     }
 
-    PhysicalDeviceShaderDrawParameterFeatures & setPNext( void* pNext_ )
+    PhysicalDeviceShaderDrawParametersFeatures & setPNext( void* pNext_ )
     {
       pNext = pNext_;
       return *this;
     }
 
-    PhysicalDeviceShaderDrawParameterFeatures & setShaderDrawParameters( Bool32 shaderDrawParameters_ )
+    PhysicalDeviceShaderDrawParametersFeatures & setShaderDrawParameters( Bool32 shaderDrawParameters_ )
     {
       shaderDrawParameters = shaderDrawParameters_;
       return *this;
     }
 
-    operator VkPhysicalDeviceShaderDrawParameterFeatures const&() const
+    operator VkPhysicalDeviceShaderDrawParametersFeatures const&() const
     {
-      return *reinterpret_cast<const VkPhysicalDeviceShaderDrawParameterFeatures*>( this );
+      return *reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>( this );
     }
 
-    operator VkPhysicalDeviceShaderDrawParameterFeatures &()
+    operator VkPhysicalDeviceShaderDrawParametersFeatures &()
     {
-      return *reinterpret_cast<VkPhysicalDeviceShaderDrawParameterFeatures*>( this );
+      return *reinterpret_cast<VkPhysicalDeviceShaderDrawParametersFeatures*>( this );
     }
 
-    bool operator==( PhysicalDeviceShaderDrawParameterFeatures const& rhs ) const
+    bool operator==( PhysicalDeviceShaderDrawParametersFeatures const& rhs ) const
     {
       return ( sType == rhs.sType )
           && ( pNext == rhs.pNext )
           && ( shaderDrawParameters == rhs.shaderDrawParameters );
     }
 
-    bool operator!=( PhysicalDeviceShaderDrawParameterFeatures const& rhs ) const
+    bool operator!=( PhysicalDeviceShaderDrawParametersFeatures const& rhs ) const
     {
       return !operator==( rhs );
     }
 
   private:
-    StructureType sType = StructureType::ePhysicalDeviceShaderDrawParameterFeatures;
+    StructureType sType = StructureType::ePhysicalDeviceShaderDrawParametersFeatures;
 
   public:
     void* pNext = nullptr;
     Bool32 shaderDrawParameters;
   };
-  static_assert( sizeof( PhysicalDeviceShaderDrawParameterFeatures ) == sizeof( VkPhysicalDeviceShaderDrawParameterFeatures ), "struct and wrapper have different size!" );
+  static_assert( sizeof( PhysicalDeviceShaderDrawParametersFeatures ) == sizeof( VkPhysicalDeviceShaderDrawParametersFeatures ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceShaderImageFootprintFeaturesNV
   {
@@ -39827,54 +40428,114 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PhysicalDeviceTransformFeedbackPropertiesEXT ) == sizeof( VkPhysicalDeviceTransformFeedbackPropertiesEXT ), "struct and wrapper have different size!" );
 
-  struct PhysicalDeviceVariablePointerFeatures
+  struct PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR
   {
-    PhysicalDeviceVariablePointerFeatures( Bool32 variablePointersStorageBuffer_ = 0,
-                                           Bool32 variablePointers_ = 0 )
-      : variablePointersStorageBuffer( variablePointersStorageBuffer_ )
-      , variablePointers( variablePointers_ )
+    PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR( Bool32 uniformBufferStandardLayout_ = 0 )
+      : uniformBufferStandardLayout( uniformBufferStandardLayout_ )
     {}
 
-    PhysicalDeviceVariablePointerFeatures( VkPhysicalDeviceVariablePointerFeatures const & rhs )
+    PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR( VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceVariablePointerFeatures ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR ) );
     }
 
-    PhysicalDeviceVariablePointerFeatures& operator=( VkPhysicalDeviceVariablePointerFeatures const & rhs )
+    PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR& operator=( VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceVariablePointerFeatures ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR ) );
       return *this;
     }
 
-    PhysicalDeviceVariablePointerFeatures & setPNext( void* pNext_ )
+    PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR & setPNext( void* pNext_ )
     {
       pNext = pNext_;
       return *this;
     }
 
-    PhysicalDeviceVariablePointerFeatures & setVariablePointersStorageBuffer( Bool32 variablePointersStorageBuffer_ )
+    PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR & setUniformBufferStandardLayout( Bool32 uniformBufferStandardLayout_ )
+    {
+      uniformBufferStandardLayout = uniformBufferStandardLayout_;
+      return *this;
+    }
+
+    operator VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR const&() const
+    {
+      return *reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR*>( this );
+    }
+
+    operator VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR &()
+    {
+      return *reinterpret_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR*>( this );
+    }
+
+    bool operator==( PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( uniformBufferStandardLayout == rhs.uniformBufferStandardLayout );
+    }
+
+    bool operator!=( PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::ePhysicalDeviceUniformBufferStandardLayoutFeaturesKHR;
+
+  public:
+    void* pNext = nullptr;
+    Bool32 uniformBufferStandardLayout;
+  };
+  static_assert( sizeof( PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR ) == sizeof( VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR ), "struct and wrapper have different size!" );
+
+  struct PhysicalDeviceVariablePointersFeatures
+  {
+    PhysicalDeviceVariablePointersFeatures( Bool32 variablePointersStorageBuffer_ = 0,
+                                            Bool32 variablePointers_ = 0 )
+      : variablePointersStorageBuffer( variablePointersStorageBuffer_ )
+      , variablePointers( variablePointers_ )
+    {}
+
+    PhysicalDeviceVariablePointersFeatures( VkPhysicalDeviceVariablePointersFeatures const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PhysicalDeviceVariablePointersFeatures ) );
+    }
+
+    PhysicalDeviceVariablePointersFeatures& operator=( VkPhysicalDeviceVariablePointersFeatures const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PhysicalDeviceVariablePointersFeatures ) );
+      return *this;
+    }
+
+    PhysicalDeviceVariablePointersFeatures & setPNext( void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PhysicalDeviceVariablePointersFeatures & setVariablePointersStorageBuffer( Bool32 variablePointersStorageBuffer_ )
     {
       variablePointersStorageBuffer = variablePointersStorageBuffer_;
       return *this;
     }
 
-    PhysicalDeviceVariablePointerFeatures & setVariablePointers( Bool32 variablePointers_ )
+    PhysicalDeviceVariablePointersFeatures & setVariablePointers( Bool32 variablePointers_ )
     {
       variablePointers = variablePointers_;
       return *this;
     }
 
-    operator VkPhysicalDeviceVariablePointerFeatures const&() const
+    operator VkPhysicalDeviceVariablePointersFeatures const&() const
     {
-      return *reinterpret_cast<const VkPhysicalDeviceVariablePointerFeatures*>( this );
+      return *reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>( this );
     }
 
-    operator VkPhysicalDeviceVariablePointerFeatures &()
+    operator VkPhysicalDeviceVariablePointersFeatures &()
     {
-      return *reinterpret_cast<VkPhysicalDeviceVariablePointerFeatures*>( this );
+      return *reinterpret_cast<VkPhysicalDeviceVariablePointersFeatures*>( this );
     }
 
-    bool operator==( PhysicalDeviceVariablePointerFeatures const& rhs ) const
+    bool operator==( PhysicalDeviceVariablePointersFeatures const& rhs ) const
     {
       return ( sType == rhs.sType )
           && ( pNext == rhs.pNext )
@@ -39882,20 +40543,20 @@ namespace VULKAN_HPP_NAMESPACE
           && ( variablePointers == rhs.variablePointers );
     }
 
-    bool operator!=( PhysicalDeviceVariablePointerFeatures const& rhs ) const
+    bool operator!=( PhysicalDeviceVariablePointersFeatures const& rhs ) const
     {
       return !operator==( rhs );
     }
 
   private:
-    StructureType sType = StructureType::ePhysicalDeviceVariablePointerFeatures;
+    StructureType sType = StructureType::ePhysicalDeviceVariablePointersFeatures;
 
   public:
     void* pNext = nullptr;
     Bool32 variablePointersStorageBuffer;
     Bool32 variablePointers;
   };
-  static_assert( sizeof( PhysicalDeviceVariablePointerFeatures ) == sizeof( VkPhysicalDeviceVariablePointerFeatures ), "struct and wrapper have different size!" );
+  static_assert( sizeof( PhysicalDeviceVariablePointersFeatures ) == sizeof( VkPhysicalDeviceVariablePointersFeatures ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceVertexAttributeDivisorFeaturesEXT
   {
@@ -40400,6 +41061,76 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PipelineCoverageModulationStateCreateInfoNV ) == sizeof( VkPipelineCoverageModulationStateCreateInfoNV ), "struct and wrapper have different size!" );
 
+  struct PipelineCoverageReductionStateCreateInfoNV
+  {
+    PipelineCoverageReductionStateCreateInfoNV( PipelineCoverageReductionStateCreateFlagsNV flags_ = PipelineCoverageReductionStateCreateFlagsNV(),
+                                                CoverageReductionModeNV coverageReductionMode_ = CoverageReductionModeNV::eMerge )
+      : flags( flags_ )
+      , coverageReductionMode( coverageReductionMode_ )
+    {}
+
+    PipelineCoverageReductionStateCreateInfoNV( VkPipelineCoverageReductionStateCreateInfoNV const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PipelineCoverageReductionStateCreateInfoNV ) );
+    }
+
+    PipelineCoverageReductionStateCreateInfoNV& operator=( VkPipelineCoverageReductionStateCreateInfoNV const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PipelineCoverageReductionStateCreateInfoNV ) );
+      return *this;
+    }
+
+    PipelineCoverageReductionStateCreateInfoNV & setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PipelineCoverageReductionStateCreateInfoNV & setFlags( PipelineCoverageReductionStateCreateFlagsNV flags_ )
+    {
+      flags = flags_;
+      return *this;
+    }
+
+    PipelineCoverageReductionStateCreateInfoNV & setCoverageReductionMode( CoverageReductionModeNV coverageReductionMode_ )
+    {
+      coverageReductionMode = coverageReductionMode_;
+      return *this;
+    }
+
+    operator VkPipelineCoverageReductionStateCreateInfoNV const&() const
+    {
+      return *reinterpret_cast<const VkPipelineCoverageReductionStateCreateInfoNV*>( this );
+    }
+
+    operator VkPipelineCoverageReductionStateCreateInfoNV &()
+    {
+      return *reinterpret_cast<VkPipelineCoverageReductionStateCreateInfoNV*>( this );
+    }
+
+    bool operator==( PipelineCoverageReductionStateCreateInfoNV const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( flags == rhs.flags )
+          && ( coverageReductionMode == rhs.coverageReductionMode );
+    }
+
+    bool operator!=( PipelineCoverageReductionStateCreateInfoNV const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::ePipelineCoverageReductionStateCreateInfoNV;
+
+  public:
+    const void* pNext = nullptr;
+    PipelineCoverageReductionStateCreateFlagsNV flags;
+    CoverageReductionModeNV coverageReductionMode;
+  };
+  static_assert( sizeof( PipelineCoverageReductionStateCreateInfoNV ) == sizeof( VkPipelineCoverageReductionStateCreateInfoNV ), "struct and wrapper have different size!" );
+
   struct PipelineCoverageToColorStateCreateInfoNV
   {
     PipelineCoverageToColorStateCreateInfoNV( PipelineCoverageToColorStateCreateFlagsNV flags_ = PipelineCoverageToColorStateCreateFlagsNV(),
@@ -40479,6 +41210,114 @@ namespace VULKAN_HPP_NAMESPACE
     uint32_t coverageToColorLocation;
   };
   static_assert( sizeof( PipelineCoverageToColorStateCreateInfoNV ) == sizeof( VkPipelineCoverageToColorStateCreateInfoNV ), "struct and wrapper have different size!" );
+
+  struct PipelineCreationFeedbackEXT
+  {
+    operator VkPipelineCreationFeedbackEXT const&() const
+    {
+      return *reinterpret_cast<const VkPipelineCreationFeedbackEXT*>( this );
+    }
+
+    operator VkPipelineCreationFeedbackEXT &()
+    {
+      return *reinterpret_cast<VkPipelineCreationFeedbackEXT*>( this );
+    }
+
+    bool operator==( PipelineCreationFeedbackEXT const& rhs ) const
+    {
+      return ( flags == rhs.flags )
+          && ( duration == rhs.duration );
+    }
+
+    bool operator!=( PipelineCreationFeedbackEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+    PipelineCreationFeedbackFlagsEXT flags;
+    uint64_t duration;
+  };
+  static_assert( sizeof( PipelineCreationFeedbackEXT ) == sizeof( VkPipelineCreationFeedbackEXT ), "struct and wrapper have different size!" );
+
+  struct PipelineCreationFeedbackCreateInfoEXT
+  {
+    PipelineCreationFeedbackCreateInfoEXT( PipelineCreationFeedbackEXT* pPipelineCreationFeedback_ = nullptr,
+                                           uint32_t pipelineStageCreationFeedbackCount_ = 0,
+                                           PipelineCreationFeedbackEXT* pPipelineStageCreationFeedbacks_ = nullptr )
+      : pPipelineCreationFeedback( pPipelineCreationFeedback_ )
+      , pipelineStageCreationFeedbackCount( pipelineStageCreationFeedbackCount_ )
+      , pPipelineStageCreationFeedbacks( pPipelineStageCreationFeedbacks_ )
+    {}
+
+    PipelineCreationFeedbackCreateInfoEXT( VkPipelineCreationFeedbackCreateInfoEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PipelineCreationFeedbackCreateInfoEXT ) );
+    }
+
+    PipelineCreationFeedbackCreateInfoEXT& operator=( VkPipelineCreationFeedbackCreateInfoEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PipelineCreationFeedbackCreateInfoEXT ) );
+      return *this;
+    }
+
+    PipelineCreationFeedbackCreateInfoEXT & setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PipelineCreationFeedbackCreateInfoEXT & setPPipelineCreationFeedback( PipelineCreationFeedbackEXT* pPipelineCreationFeedback_ )
+    {
+      pPipelineCreationFeedback = pPipelineCreationFeedback_;
+      return *this;
+    }
+
+    PipelineCreationFeedbackCreateInfoEXT & setPipelineStageCreationFeedbackCount( uint32_t pipelineStageCreationFeedbackCount_ )
+    {
+      pipelineStageCreationFeedbackCount = pipelineStageCreationFeedbackCount_;
+      return *this;
+    }
+
+    PipelineCreationFeedbackCreateInfoEXT & setPPipelineStageCreationFeedbacks( PipelineCreationFeedbackEXT* pPipelineStageCreationFeedbacks_ )
+    {
+      pPipelineStageCreationFeedbacks = pPipelineStageCreationFeedbacks_;
+      return *this;
+    }
+
+    operator VkPipelineCreationFeedbackCreateInfoEXT const&() const
+    {
+      return *reinterpret_cast<const VkPipelineCreationFeedbackCreateInfoEXT*>( this );
+    }
+
+    operator VkPipelineCreationFeedbackCreateInfoEXT &()
+    {
+      return *reinterpret_cast<VkPipelineCreationFeedbackCreateInfoEXT*>( this );
+    }
+
+    bool operator==( PipelineCreationFeedbackCreateInfoEXT const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( pPipelineCreationFeedback == rhs.pPipelineCreationFeedback )
+          && ( pipelineStageCreationFeedbackCount == rhs.pipelineStageCreationFeedbackCount )
+          && ( pPipelineStageCreationFeedbacks == rhs.pPipelineStageCreationFeedbacks );
+    }
+
+    bool operator!=( PipelineCreationFeedbackCreateInfoEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::ePipelineCreationFeedbackCreateInfoEXT;
+
+  public:
+    const void* pNext = nullptr;
+    PipelineCreationFeedbackEXT* pPipelineCreationFeedback;
+    uint32_t pipelineStageCreationFeedbackCount;
+    PipelineCreationFeedbackEXT* pPipelineStageCreationFeedbacks;
+  };
+  static_assert( sizeof( PipelineCreationFeedbackCreateInfoEXT ) == sizeof( VkPipelineCreationFeedbackCreateInfoEXT ), "struct and wrapper have different size!" );
 
   struct PipelineDiscardRectangleStateCreateInfoEXT
   {
@@ -41914,6 +42753,68 @@ namespace VULKAN_HPP_NAMESPACE
     const ViewportWScalingNV* pViewportWScalings;
   };
   static_assert( sizeof( PipelineViewportWScalingStateCreateInfoNV ) == sizeof( VkPipelineViewportWScalingStateCreateInfoNV ), "struct and wrapper have different size!" );
+
+#ifdef VK_USE_PLATFORM_GGP
+  struct PresentFrameTokenGGP
+  {
+    PresentFrameTokenGGP( GgpFrameToken frameToken_ = 0 )
+      : frameToken( frameToken_ )
+    {}
+
+    PresentFrameTokenGGP( VkPresentFrameTokenGGP const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PresentFrameTokenGGP ) );
+    }
+
+    PresentFrameTokenGGP& operator=( VkPresentFrameTokenGGP const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( PresentFrameTokenGGP ) );
+      return *this;
+    }
+
+    PresentFrameTokenGGP & setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PresentFrameTokenGGP & setFrameToken( GgpFrameToken frameToken_ )
+    {
+      frameToken = frameToken_;
+      return *this;
+    }
+
+    operator VkPresentFrameTokenGGP const&() const
+    {
+      return *reinterpret_cast<const VkPresentFrameTokenGGP*>( this );
+    }
+
+    operator VkPresentFrameTokenGGP &()
+    {
+      return *reinterpret_cast<VkPresentFrameTokenGGP*>( this );
+    }
+
+    bool operator==( PresentFrameTokenGGP const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( frameToken == rhs.frameToken );
+    }
+
+    bool operator!=( PresentFrameTokenGGP const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::ePresentFrameTokenGGP;
+
+  public:
+    const void* pNext = nullptr;
+    GgpFrameToken frameToken;
+  };
+  static_assert( sizeof( PresentFrameTokenGGP ) == sizeof( VkPresentFrameTokenGGP ), "struct and wrapper have different size!" );
+#endif /*VK_USE_PLATFORM_GGP*/
 
   struct PresentInfoKHR
   {
@@ -45218,6 +46119,78 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( SparseImageMemoryRequirements2 ) == sizeof( VkSparseImageMemoryRequirements2 ), "struct and wrapper have different size!" );
 
+#ifdef VK_USE_PLATFORM_GGP
+  struct StreamDescriptorSurfaceCreateInfoGGP
+  {
+    StreamDescriptorSurfaceCreateInfoGGP( StreamDescriptorSurfaceCreateFlagsGGP flags_ = StreamDescriptorSurfaceCreateFlagsGGP(),
+                                          GgpStreamDescriptor streamDescriptor_ = 0 )
+      : flags( flags_ )
+      , streamDescriptor( streamDescriptor_ )
+    {}
+
+    StreamDescriptorSurfaceCreateInfoGGP( VkStreamDescriptorSurfaceCreateInfoGGP const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( StreamDescriptorSurfaceCreateInfoGGP ) );
+    }
+
+    StreamDescriptorSurfaceCreateInfoGGP& operator=( VkStreamDescriptorSurfaceCreateInfoGGP const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( StreamDescriptorSurfaceCreateInfoGGP ) );
+      return *this;
+    }
+
+    StreamDescriptorSurfaceCreateInfoGGP & setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    StreamDescriptorSurfaceCreateInfoGGP & setFlags( StreamDescriptorSurfaceCreateFlagsGGP flags_ )
+    {
+      flags = flags_;
+      return *this;
+    }
+
+    StreamDescriptorSurfaceCreateInfoGGP & setStreamDescriptor( GgpStreamDescriptor streamDescriptor_ )
+    {
+      streamDescriptor = streamDescriptor_;
+      return *this;
+    }
+
+    operator VkStreamDescriptorSurfaceCreateInfoGGP const&() const
+    {
+      return *reinterpret_cast<const VkStreamDescriptorSurfaceCreateInfoGGP*>( this );
+    }
+
+    operator VkStreamDescriptorSurfaceCreateInfoGGP &()
+    {
+      return *reinterpret_cast<VkStreamDescriptorSurfaceCreateInfoGGP*>( this );
+    }
+
+    bool operator==( StreamDescriptorSurfaceCreateInfoGGP const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( flags == rhs.flags )
+          && ( streamDescriptor == rhs.streamDescriptor );
+    }
+
+    bool operator!=( StreamDescriptorSurfaceCreateInfoGGP const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eStreamDescriptorSurfaceCreateInfoGGP;
+
+  public:
+    const void* pNext = nullptr;
+    StreamDescriptorSurfaceCreateFlagsGGP flags;
+    GgpStreamDescriptor streamDescriptor;
+  };
+  static_assert( sizeof( StreamDescriptorSurfaceCreateInfoGGP ) == sizeof( VkStreamDescriptorSurfaceCreateInfoGGP ), "struct and wrapper have different size!" );
+#endif /*VK_USE_PLATFORM_GGP*/
+
   struct SubmitInfo
   {
     SubmitInfo( uint32_t waitSemaphoreCount_ = 0,
@@ -45659,6 +46632,68 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( SurfaceCapabilities2KHR ) == sizeof( VkSurfaceCapabilities2KHR ), "struct and wrapper have different size!" );
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  struct SurfaceCapabilitiesFullScreenExclusiveEXT
+  {
+    SurfaceCapabilitiesFullScreenExclusiveEXT( Bool32 fullScreenExclusiveSupported_ = 0 )
+      : fullScreenExclusiveSupported( fullScreenExclusiveSupported_ )
+    {}
+
+    SurfaceCapabilitiesFullScreenExclusiveEXT( VkSurfaceCapabilitiesFullScreenExclusiveEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SurfaceCapabilitiesFullScreenExclusiveEXT ) );
+    }
+
+    SurfaceCapabilitiesFullScreenExclusiveEXT& operator=( VkSurfaceCapabilitiesFullScreenExclusiveEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SurfaceCapabilitiesFullScreenExclusiveEXT ) );
+      return *this;
+    }
+
+    SurfaceCapabilitiesFullScreenExclusiveEXT & setPNext( void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    SurfaceCapabilitiesFullScreenExclusiveEXT & setFullScreenExclusiveSupported( Bool32 fullScreenExclusiveSupported_ )
+    {
+      fullScreenExclusiveSupported = fullScreenExclusiveSupported_;
+      return *this;
+    }
+
+    operator VkSurfaceCapabilitiesFullScreenExclusiveEXT const&() const
+    {
+      return *reinterpret_cast<const VkSurfaceCapabilitiesFullScreenExclusiveEXT*>( this );
+    }
+
+    operator VkSurfaceCapabilitiesFullScreenExclusiveEXT &()
+    {
+      return *reinterpret_cast<VkSurfaceCapabilitiesFullScreenExclusiveEXT*>( this );
+    }
+
+    bool operator==( SurfaceCapabilitiesFullScreenExclusiveEXT const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( fullScreenExclusiveSupported == rhs.fullScreenExclusiveSupported );
+    }
+
+    bool operator!=( SurfaceCapabilitiesFullScreenExclusiveEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eSurfaceCapabilitiesFullScreenExclusiveEXT;
+
+  public:
+    void* pNext = nullptr;
+    Bool32 fullScreenExclusiveSupported;
+  };
+  static_assert( sizeof( SurfaceCapabilitiesFullScreenExclusiveEXT ) == sizeof( VkSurfaceCapabilitiesFullScreenExclusiveEXT ), "struct and wrapper have different size!" );
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
   struct SurfaceFormatKHR
   {
     operator VkSurfaceFormatKHR const&() const
@@ -45719,6 +46754,190 @@ namespace VULKAN_HPP_NAMESPACE
     SurfaceFormatKHR surfaceFormat;
   };
   static_assert( sizeof( SurfaceFormat2KHR ) == sizeof( VkSurfaceFormat2KHR ), "struct and wrapper have different size!" );
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  struct SurfaceFullScreenExclusiveInfoEXT
+  {
+    SurfaceFullScreenExclusiveInfoEXT( FullScreenExclusiveEXT fullScreenExclusive_ = FullScreenExclusiveEXT::eDefault )
+      : fullScreenExclusive( fullScreenExclusive_ )
+    {}
+
+    SurfaceFullScreenExclusiveInfoEXT( VkSurfaceFullScreenExclusiveInfoEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SurfaceFullScreenExclusiveInfoEXT ) );
+    }
+
+    SurfaceFullScreenExclusiveInfoEXT& operator=( VkSurfaceFullScreenExclusiveInfoEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SurfaceFullScreenExclusiveInfoEXT ) );
+      return *this;
+    }
+
+    SurfaceFullScreenExclusiveInfoEXT & setPNext( void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    SurfaceFullScreenExclusiveInfoEXT & setFullScreenExclusive( FullScreenExclusiveEXT fullScreenExclusive_ )
+    {
+      fullScreenExclusive = fullScreenExclusive_;
+      return *this;
+    }
+
+    operator VkSurfaceFullScreenExclusiveInfoEXT const&() const
+    {
+      return *reinterpret_cast<const VkSurfaceFullScreenExclusiveInfoEXT*>( this );
+    }
+
+    operator VkSurfaceFullScreenExclusiveInfoEXT &()
+    {
+      return *reinterpret_cast<VkSurfaceFullScreenExclusiveInfoEXT*>( this );
+    }
+
+    bool operator==( SurfaceFullScreenExclusiveInfoEXT const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( fullScreenExclusive == rhs.fullScreenExclusive );
+    }
+
+    bool operator!=( SurfaceFullScreenExclusiveInfoEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eSurfaceFullScreenExclusiveInfoEXT;
+
+  public:
+    void* pNext = nullptr;
+    FullScreenExclusiveEXT fullScreenExclusive;
+  };
+  static_assert( sizeof( SurfaceFullScreenExclusiveInfoEXT ) == sizeof( VkSurfaceFullScreenExclusiveInfoEXT ), "struct and wrapper have different size!" );
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  struct SurfaceFullScreenExclusiveWin32InfoEXT
+  {
+    SurfaceFullScreenExclusiveWin32InfoEXT( HMONITOR hmonitor_ = 0 )
+      : hmonitor( hmonitor_ )
+    {}
+
+    SurfaceFullScreenExclusiveWin32InfoEXT( VkSurfaceFullScreenExclusiveWin32InfoEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SurfaceFullScreenExclusiveWin32InfoEXT ) );
+    }
+
+    SurfaceFullScreenExclusiveWin32InfoEXT& operator=( VkSurfaceFullScreenExclusiveWin32InfoEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SurfaceFullScreenExclusiveWin32InfoEXT ) );
+      return *this;
+    }
+
+    SurfaceFullScreenExclusiveWin32InfoEXT & setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    SurfaceFullScreenExclusiveWin32InfoEXT & setHmonitor( HMONITOR hmonitor_ )
+    {
+      hmonitor = hmonitor_;
+      return *this;
+    }
+
+    operator VkSurfaceFullScreenExclusiveWin32InfoEXT const&() const
+    {
+      return *reinterpret_cast<const VkSurfaceFullScreenExclusiveWin32InfoEXT*>( this );
+    }
+
+    operator VkSurfaceFullScreenExclusiveWin32InfoEXT &()
+    {
+      return *reinterpret_cast<VkSurfaceFullScreenExclusiveWin32InfoEXT*>( this );
+    }
+
+    bool operator==( SurfaceFullScreenExclusiveWin32InfoEXT const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( hmonitor == rhs.hmonitor );
+    }
+
+    bool operator!=( SurfaceFullScreenExclusiveWin32InfoEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eSurfaceFullScreenExclusiveWin32InfoEXT;
+
+  public:
+    const void* pNext = nullptr;
+    HMONITOR hmonitor;
+  };
+  static_assert( sizeof( SurfaceFullScreenExclusiveWin32InfoEXT ) == sizeof( VkSurfaceFullScreenExclusiveWin32InfoEXT ), "struct and wrapper have different size!" );
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+  struct SurfaceProtectedCapabilitiesKHR
+  {
+    SurfaceProtectedCapabilitiesKHR( Bool32 supportsProtected_ = 0 )
+      : supportsProtected( supportsProtected_ )
+    {}
+
+    SurfaceProtectedCapabilitiesKHR( VkSurfaceProtectedCapabilitiesKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SurfaceProtectedCapabilitiesKHR ) );
+    }
+
+    SurfaceProtectedCapabilitiesKHR& operator=( VkSurfaceProtectedCapabilitiesKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SurfaceProtectedCapabilitiesKHR ) );
+      return *this;
+    }
+
+    SurfaceProtectedCapabilitiesKHR & setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    SurfaceProtectedCapabilitiesKHR & setSupportsProtected( Bool32 supportsProtected_ )
+    {
+      supportsProtected = supportsProtected_;
+      return *this;
+    }
+
+    operator VkSurfaceProtectedCapabilitiesKHR const&() const
+    {
+      return *reinterpret_cast<const VkSurfaceProtectedCapabilitiesKHR*>( this );
+    }
+
+    operator VkSurfaceProtectedCapabilitiesKHR &()
+    {
+      return *reinterpret_cast<VkSurfaceProtectedCapabilitiesKHR*>( this );
+    }
+
+    bool operator==( SurfaceProtectedCapabilitiesKHR const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( supportsProtected == rhs.supportsProtected );
+    }
+
+    bool operator!=( SurfaceProtectedCapabilitiesKHR const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eSurfaceProtectedCapabilitiesKHR;
+
+  public:
+    const void* pNext = nullptr;
+    Bool32 supportsProtected;
+  };
+  static_assert( sizeof( SurfaceProtectedCapabilitiesKHR ) == sizeof( VkSurfaceProtectedCapabilitiesKHR ), "struct and wrapper have different size!" );
 
   struct SwapchainCounterCreateInfoEXT
   {
@@ -45989,6 +47208,66 @@ namespace VULKAN_HPP_NAMESPACE
     SwapchainKHR oldSwapchain;
   };
   static_assert( sizeof( SwapchainCreateInfoKHR ) == sizeof( VkSwapchainCreateInfoKHR ), "struct and wrapper have different size!" );
+
+  struct SwapchainDisplayNativeHdrCreateInfoAMD
+  {
+    SwapchainDisplayNativeHdrCreateInfoAMD( Bool32 localDimmingEnable_ = 0 )
+      : localDimmingEnable( localDimmingEnable_ )
+    {}
+
+    SwapchainDisplayNativeHdrCreateInfoAMD( VkSwapchainDisplayNativeHdrCreateInfoAMD const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SwapchainDisplayNativeHdrCreateInfoAMD ) );
+    }
+
+    SwapchainDisplayNativeHdrCreateInfoAMD& operator=( VkSwapchainDisplayNativeHdrCreateInfoAMD const & rhs )
+    {
+      memcpy( this, &rhs, sizeof( SwapchainDisplayNativeHdrCreateInfoAMD ) );
+      return *this;
+    }
+
+    SwapchainDisplayNativeHdrCreateInfoAMD & setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    SwapchainDisplayNativeHdrCreateInfoAMD & setLocalDimmingEnable( Bool32 localDimmingEnable_ )
+    {
+      localDimmingEnable = localDimmingEnable_;
+      return *this;
+    }
+
+    operator VkSwapchainDisplayNativeHdrCreateInfoAMD const&() const
+    {
+      return *reinterpret_cast<const VkSwapchainDisplayNativeHdrCreateInfoAMD*>( this );
+    }
+
+    operator VkSwapchainDisplayNativeHdrCreateInfoAMD &()
+    {
+      return *reinterpret_cast<VkSwapchainDisplayNativeHdrCreateInfoAMD*>( this );
+    }
+
+    bool operator==( SwapchainDisplayNativeHdrCreateInfoAMD const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( localDimmingEnable == rhs.localDimmingEnable );
+    }
+
+    bool operator!=( SwapchainDisplayNativeHdrCreateInfoAMD const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType = StructureType::eSwapchainDisplayNativeHdrCreateInfoAMD;
+
+  public:
+    const void* pNext = nullptr;
+    Bool32 localDimmingEnable;
+  };
+  static_assert( sizeof( SwapchainDisplayNativeHdrCreateInfoAMD ) == sizeof( VkSwapchainDisplayNativeHdrCreateInfoAMD ), "struct and wrapper have different size!" );
 
   struct TextureLODGatherFormatPropertiesAMD
   {
@@ -48619,6 +49898,23 @@ namespace VULKAN_HPP_NAMESPACE
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE Result Device::acquireFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d) const
+  {
+    return static_cast<Result>( d.vkAcquireFullScreenExclusiveModeEXT( m_device, static_cast<VkSwapchainKHR>( swapchain ) ) );
+  }
+#else
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE ResultValueType<void>::type Device::acquireFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d ) const
+  {
+    Result result = static_cast<Result>( d.vkAcquireFullScreenExclusiveModeEXT( m_device, static_cast<VkSwapchainKHR>( swapchain ) ) );
+    return createResultValue( result, VULKAN_HPP_NAMESPACE_STRING"::Device::acquireFullScreenExclusiveModeEXT" );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Device::acquireNextImage2KHR( const AcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex, Dispatch const &d) const
   {
@@ -51018,6 +52314,23 @@ namespace VULKAN_HPP_NAMESPACE
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE Result Device::getGroupSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, DeviceGroupPresentModeFlagsKHR* pModes, Dispatch const &d) const
+  {
+    return static_cast<Result>( d.vkGetDeviceGroupSurfacePresentModes2EXT( m_device, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( pSurfaceInfo ), reinterpret_cast<VkDeviceGroupPresentModeFlagsKHR*>( pModes ) ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE ResultValueType<DeviceGroupPresentModeFlagsKHR>::type Device::getGroupSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Dispatch const &d ) const
+  {
+    DeviceGroupPresentModeFlagsKHR modes;
+    Result result = static_cast<Result>( d.vkGetDeviceGroupSurfacePresentModes2EXT( m_device, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), reinterpret_cast<VkDeviceGroupPresentModeFlagsKHR*>( &modes ) ) );
+    return createResultValue( result, modes, VULKAN_HPP_NAMESPACE_STRING"::Device::getGroupSurfacePresentModes2EXT" );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Device::getGroupSurfacePresentModesKHR( SurfaceKHR surface, DeviceGroupPresentModeFlagsKHR* pModes, Dispatch const &d) const
   {
@@ -52003,6 +53316,23 @@ namespace VULKAN_HPP_NAMESPACE
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE Result Device::releaseFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d) const
+  {
+    return static_cast<Result>( d.vkReleaseFullScreenExclusiveModeEXT( m_device, static_cast<VkSwapchainKHR>( swapchain ) ) );
+  }
+#else
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE ResultValueType<void>::type Device::releaseFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d ) const
+  {
+    Result result = static_cast<Result>( d.vkReleaseFullScreenExclusiveModeEXT( m_device, static_cast<VkSwapchainKHR>( swapchain ) ) );
+    return createResultValue( result, VULKAN_HPP_NAMESPACE_STRING"::Device::releaseFullScreenExclusiveModeEXT" );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
 #ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Device::resetCommandPool( CommandPool commandPool, CommandPoolResetFlags flags, Dispatch const &d) const
@@ -52059,6 +53389,20 @@ namespace VULKAN_HPP_NAMESPACE
   {
     Result result = static_cast<Result>( d.vkResetFences( m_device, fences.size() , reinterpret_cast<const VkFence*>( fences.data() ) ) );
     return createResultValue( result, VULKAN_HPP_NAMESPACE_STRING"::Device::resetFences" );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE void Device::resetQueryPoolEXT( QueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, Dispatch const &d) const
+  {
+    d.vkResetQueryPoolEXT( m_device, static_cast<VkQueryPool>( queryPool ), firstQuery, queryCount );
+  }
+#else
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE void Device::resetQueryPoolEXT( QueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, Dispatch const &d ) const
+  {
+    d.vkResetQueryPoolEXT( m_device, static_cast<VkQueryPool>( queryPool ), firstQuery, queryCount );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -52123,6 +53467,20 @@ namespace VULKAN_HPP_NAMESPACE
     }
 #endif  /*VULKAN_HPP_NO_EXCEPTIONS*/
     d.vkSetHdrMetadataEXT( m_device, swapchains.size() , reinterpret_cast<const VkSwapchainKHR*>( swapchains.data() ), reinterpret_cast<const VkHdrMetadataEXT*>( metadata.data() ) );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE void Device::setLocalDimmingAMD( SwapchainKHR swapChain, Bool32 localDimmingEnable, Dispatch const &d) const
+  {
+    d.vkSetLocalDimmingAMD( m_device, static_cast<VkSwapchainKHR>( swapChain ), static_cast<VkBool32>( localDimmingEnable ) );
+  }
+#else
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE void Device::setLocalDimmingAMD( SwapchainKHR swapChain, Bool32 localDimmingEnable, Dispatch const &d ) const
+  {
+    d.vkSetLocalDimmingAMD( m_device, static_cast<VkSwapchainKHR>( swapChain ), static_cast<VkBool32>( localDimmingEnable ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -52351,6 +53709,32 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE Result Instance::createHeadlessSurfaceEXT( const HeadlessSurfaceCreateInfoEXT* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d) const
+  {
+    return static_cast<Result>( d.vkCreateHeadlessSurfaceEXT( m_instance, reinterpret_cast<const VkHeadlessSurfaceCreateInfoEXT*>( pCreateInfo ), reinterpret_cast<const VkAllocationCallbacks*>( pAllocator ), reinterpret_cast<VkSurfaceKHR*>( pSurface ) ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createHeadlessSurfaceEXT( const HeadlessSurfaceCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
+  {
+    SurfaceKHR surface;
+    Result result = static_cast<Result>( d.vkCreateHeadlessSurfaceEXT( m_instance, reinterpret_cast<const VkHeadlessSurfaceCreateInfoEXT*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    return createResultValue( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createHeadlessSurfaceEXT" );
+  }
+#ifndef VULKAN_HPP_NO_SMART_HANDLE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type Instance::createHeadlessSurfaceEXTUnique( const HeadlessSurfaceCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
+  {
+    SurfaceKHR surface;
+    Result result = static_cast<Result>( d.vkCreateHeadlessSurfaceEXT( m_instance, reinterpret_cast<const VkHeadlessSurfaceCreateInfoEXT*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+
+    ObjectDestroy<Instance,Dispatch> deleter( *this, allocator, d );
+    return createResultValue<SurfaceKHR,Dispatch>( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createHeadlessSurfaceEXTUnique", deleter );
+  }
+#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
 #ifdef VK_USE_PLATFORM_IOS_MVK
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Instance::createIOSSurfaceMVK( const IOSSurfaceCreateInfoMVK* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d) const
@@ -52462,6 +53846,34 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
+
+#ifdef VK_USE_PLATFORM_GGP
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE Result Instance::createStreamDescriptorSurfaceGGP( const StreamDescriptorSurfaceCreateInfoGGP* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d) const
+  {
+    return static_cast<Result>( d.vkCreateStreamDescriptorSurfaceGGP( m_instance, reinterpret_cast<const VkStreamDescriptorSurfaceCreateInfoGGP*>( pCreateInfo ), reinterpret_cast<const VkAllocationCallbacks*>( pAllocator ), reinterpret_cast<VkSurfaceKHR*>( pSurface ) ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createStreamDescriptorSurfaceGGP( const StreamDescriptorSurfaceCreateInfoGGP & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
+  {
+    SurfaceKHR surface;
+    Result result = static_cast<Result>( d.vkCreateStreamDescriptorSurfaceGGP( m_instance, reinterpret_cast<const VkStreamDescriptorSurfaceCreateInfoGGP*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    return createResultValue( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createStreamDescriptorSurfaceGGP" );
+  }
+#ifndef VULKAN_HPP_NO_SMART_HANDLE
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type Instance::createStreamDescriptorSurfaceGGPUnique( const StreamDescriptorSurfaceCreateInfoGGP & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
+  {
+    SurfaceKHR surface;
+    Result result = static_cast<Result>( d.vkCreateStreamDescriptorSurfaceGGP( m_instance, reinterpret_cast<const VkStreamDescriptorSurfaceCreateInfoGGP*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+
+    ObjectDestroy<Instance,Dispatch> deleter( *this, allocator, d );
+    return createResultValue<SurfaceKHR,Dispatch>( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createStreamDescriptorSurfaceGGPUnique", deleter );
+  }
+#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_GGP*/
 
 #ifdef VK_USE_PLATFORM_VI_NN
   template<typename Dispatch>
@@ -54258,6 +55670,58 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
   template<typename Dispatch>
+  VULKAN_HPP_INLINE Result PhysicalDevice::getSupportedFramebufferMixedSamplesCombinationsNV( uint32_t* pCombinationCount, FramebufferMixedSamplesCombinationNV* pCombinations, Dispatch const &d) const
+  {
+    return static_cast<Result>( d.vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV( m_physicalDevice, pCombinationCount, reinterpret_cast<VkFramebufferMixedSamplesCombinationNV*>( pCombinations ) ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Allocator, typename Dispatch>
+  VULKAN_HPP_INLINE typename ResultValueType<std::vector<FramebufferMixedSamplesCombinationNV,Allocator>>::type PhysicalDevice::getSupportedFramebufferMixedSamplesCombinationsNV(Dispatch const &d ) const
+  {
+    std::vector<FramebufferMixedSamplesCombinationNV,Allocator> combinations;
+    uint32_t combinationCount;
+    Result result;
+    do
+    {
+      result = static_cast<Result>( d.vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV( m_physicalDevice, &combinationCount, nullptr ) );
+      if ( ( result == Result::eSuccess ) && combinationCount )
+      {
+        combinations.resize( combinationCount );
+        result = static_cast<Result>( d.vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV( m_physicalDevice, &combinationCount, reinterpret_cast<VkFramebufferMixedSamplesCombinationNV*>( combinations.data() ) ) );
+      }
+    } while ( result == Result::eIncomplete );
+    if ( result == Result::eSuccess )
+    {
+      VULKAN_HPP_ASSERT( combinationCount <= combinations.size() );
+      combinations.resize( combinationCount );
+    }
+    return createResultValue( result, combinations, VULKAN_HPP_NAMESPACE_STRING"::PhysicalDevice::getSupportedFramebufferMixedSamplesCombinationsNV" );
+  }
+  template<typename Allocator, typename Dispatch>
+  VULKAN_HPP_INLINE typename ResultValueType<std::vector<FramebufferMixedSamplesCombinationNV,Allocator>>::type PhysicalDevice::getSupportedFramebufferMixedSamplesCombinationsNV(Allocator const& vectorAllocator, Dispatch const &d ) const
+  {
+    std::vector<FramebufferMixedSamplesCombinationNV,Allocator> combinations( vectorAllocator );
+    uint32_t combinationCount;
+    Result result;
+    do
+    {
+      result = static_cast<Result>( d.vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV( m_physicalDevice, &combinationCount, nullptr ) );
+      if ( ( result == Result::eSuccess ) && combinationCount )
+      {
+        combinations.resize( combinationCount );
+        result = static_cast<Result>( d.vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV( m_physicalDevice, &combinationCount, reinterpret_cast<VkFramebufferMixedSamplesCombinationNV*>( combinations.data() ) ) );
+      }
+    } while ( result == Result::eIncomplete );
+    if ( result == Result::eSuccess )
+    {
+      VULKAN_HPP_ASSERT( combinationCount <= combinations.size() );
+      combinations.resize( combinationCount );
+    }
+    return createResultValue( result, combinations, VULKAN_HPP_NAMESPACE_STRING"::PhysicalDevice::getSupportedFramebufferMixedSamplesCombinationsNV" );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+  template<typename Dispatch>
   VULKAN_HPP_INLINE Result PhysicalDevice::getSurfaceCapabilities2EXT( SurfaceKHR surface, SurfaceCapabilities2EXT* pSurfaceCapabilities, Dispatch const &d) const
   {
     return static_cast<Result>( d.vkGetPhysicalDeviceSurfaceCapabilities2EXT( m_physicalDevice, static_cast<VkSurfaceKHR>( surface ), reinterpret_cast<VkSurfaceCapabilities2EXT*>( pSurfaceCapabilities ) ) );
@@ -54413,6 +55877,60 @@ namespace VULKAN_HPP_NAMESPACE
     return createResultValue( result, surfaceFormats, VULKAN_HPP_NAMESPACE_STRING"::PhysicalDevice::getSurfaceFormatsKHR" );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  template<typename Dispatch>
+  VULKAN_HPP_INLINE Result PhysicalDevice::getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, uint32_t* pPresentModeCount, PresentModeKHR* pPresentModes, Dispatch const &d) const
+  {
+    return static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( pSurfaceInfo ), pPresentModeCount, reinterpret_cast<VkPresentModeKHR*>( pPresentModes ) ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template<typename Allocator, typename Dispatch>
+  VULKAN_HPP_INLINE typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type PhysicalDevice::getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Dispatch const &d ) const
+  {
+    std::vector<PresentModeKHR,Allocator> presentModes;
+    uint32_t presentModeCount;
+    Result result;
+    do
+    {
+      result = static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), &presentModeCount, nullptr ) );
+      if ( ( result == Result::eSuccess ) && presentModeCount )
+      {
+        presentModes.resize( presentModeCount );
+        result = static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), &presentModeCount, reinterpret_cast<VkPresentModeKHR*>( presentModes.data() ) ) );
+      }
+    } while ( result == Result::eIncomplete );
+    if ( result == Result::eSuccess )
+    {
+      VULKAN_HPP_ASSERT( presentModeCount <= presentModes.size() );
+      presentModes.resize( presentModeCount );
+    }
+    return createResultValue( result, presentModes, VULKAN_HPP_NAMESPACE_STRING"::PhysicalDevice::getSurfacePresentModes2EXT" );
+  }
+  template<typename Allocator, typename Dispatch>
+  VULKAN_HPP_INLINE typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type PhysicalDevice::getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Allocator const& vectorAllocator, Dispatch const &d ) const
+  {
+    std::vector<PresentModeKHR,Allocator> presentModes( vectorAllocator );
+    uint32_t presentModeCount;
+    Result result;
+    do
+    {
+      result = static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), &presentModeCount, nullptr ) );
+      if ( ( result == Result::eSuccess ) && presentModeCount )
+      {
+        presentModes.resize( presentModeCount );
+        result = static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), &presentModeCount, reinterpret_cast<VkPresentModeKHR*>( presentModes.data() ) ) );
+      }
+    } while ( result == Result::eIncomplete );
+    if ( result == Result::eSuccess )
+    {
+      VULKAN_HPP_ASSERT( presentModeCount <= presentModes.size() );
+      presentModes.resize( presentModeCount );
+    }
+    return createResultValue( result, presentModes, VULKAN_HPP_NAMESPACE_STRING"::PhysicalDevice::getSurfacePresentModes2EXT" );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result PhysicalDevice::getSurfacePresentModesKHR( SurfaceKHR surface, uint32_t* pPresentModeCount, PresentModeKHR* pPresentModes, Dispatch const &d) const
@@ -54732,6 +56250,7 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<SwapchainCreateInfoKHR, DeviceGroupSwapchainCreateInfoKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, DeviceMemoryOverallocationCreateInfoAMD>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceQueueCreateInfo, DeviceQueueGlobalPriorityCreateInfoEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<SurfaceCapabilities2KHR, DisplayNativeHdrSurfaceCapabilitiesAMD>{ enum { value = true }; };
   template <> struct isStructureChainValid<PresentInfoKHR, DisplayPresentInfoKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<FormatProperties2, DrmFormatModifierPropertiesListEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<FenceCreateInfo, ExportFenceCreateInfo>{ enum { value = true }; };
@@ -54794,8 +56313,8 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceBlendOperationAdvancedFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceBlendOperationAdvancedFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceBlendOperationAdvancedPropertiesEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceBufferAddressFeaturesEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceBufferAddressFeaturesEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceBufferDeviceAddressFeaturesEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceBufferDeviceAddressFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceComputeShaderDerivativesFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceComputeShaderDerivativesFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceConditionalRenderingFeaturesEXT>{ enum { value = true }; };
@@ -54806,6 +56325,8 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceCooperativeMatrixPropertiesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceCornerSampledImageFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceCornerSampledImageFeaturesNV>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceCoverageReductionModeFeaturesNV>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceCoverageReductionModeFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceDepthClipEnableFeaturesEXT>{ enum { value = true }; };
@@ -54829,6 +56350,8 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceFragmentDensityMapPropertiesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceFragmentShaderBarycentricFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceFragmentShaderBarycentricFeaturesNV>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceHostQueryResetFeaturesEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceHostQueryResetFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceIDProperties>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceImageFormatInfo2, PhysicalDeviceImageDrmFormatModifierInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceImageFormatInfo2, PhysicalDeviceImageViewImageFormatInfoEXT>{ enum { value = true }; };
@@ -54864,8 +56387,8 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderAtomicInt64FeaturesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderAtomicInt64FeaturesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceShaderCorePropertiesAMD>{ enum { value = true }; };
-  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderDrawParameterFeatures>{ enum { value = true }; };
-  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderDrawParameterFeatures>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderDrawParametersFeatures>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderDrawParametersFeatures>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderImageFootprintFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderImageFootprintFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShadingRateImageFeaturesNV>{ enum { value = true }; };
@@ -54875,8 +56398,10 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceTransformFeedbackFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceTransformFeedbackFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceTransformFeedbackPropertiesEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVariablePointerFeatures>{ enum { value = true }; };
-  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVariablePointerFeatures>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVariablePointersFeatures>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVariablePointersFeatures>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVertexAttributeDivisorFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVertexAttributeDivisorFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceVertexAttributeDivisorPropertiesEXT>{ enum { value = true }; };
@@ -54886,7 +56411,11 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceYcbcrImageArraysFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineColorBlendStateCreateInfo, PipelineColorBlendAdvancedStateCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineMultisampleStateCreateInfo, PipelineCoverageModulationStateCreateInfoNV>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PipelineMultisampleStateCreateInfo, PipelineCoverageReductionStateCreateInfoNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineMultisampleStateCreateInfo, PipelineCoverageToColorStateCreateInfoNV>{ enum { value = true }; };
+  template <> struct isStructureChainValid<GraphicsPipelineCreateInfo, PipelineCreationFeedbackCreateInfoEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<ComputePipelineCreateInfo, PipelineCreationFeedbackCreateInfoEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<RayTracingPipelineCreateInfoNV, PipelineCreationFeedbackCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<GraphicsPipelineCreateInfo, PipelineDiscardRectangleStateCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineRasterizationStateCreateInfo, PipelineRasterizationConservativeStateCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineRasterizationStateCreateInfo, PipelineRasterizationDepthClipStateCreateInfoEXT>{ enum { value = true }; };
@@ -54901,6 +56430,9 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PipelineViewportStateCreateInfo, PipelineViewportShadingRateImageStateCreateInfoNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineViewportStateCreateInfo, PipelineViewportSwizzleStateCreateInfoNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineViewportStateCreateInfo, PipelineViewportWScalingStateCreateInfoNV>{ enum { value = true }; };
+#ifdef VK_USE_PLATFORM_GGP
+  template <> struct isStructureChainValid<PresentInfoKHR, PresentFrameTokenGGP>{ enum { value = true }; };
+#endif /*VK_USE_PLATFORM_GGP*/
   template <> struct isStructureChainValid<PresentInfoKHR, PresentRegionsKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<PresentInfoKHR, PresentTimesInfoGOOGLE>{ enum { value = true }; };
   template <> struct isStructureChainValid<SubmitInfo, ProtectedSubmitInfo>{ enum { value = true }; };
@@ -54917,7 +56449,20 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<ShaderModuleCreateInfo, ShaderModuleValidationCacheCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<SurfaceCapabilities2KHR, SharedPresentSurfaceCapabilitiesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<SubpassDescription2KHR, SubpassDescriptionDepthStencilResolveKHR>{ enum { value = true }; };
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  template <> struct isStructureChainValid<SurfaceCapabilities2KHR, SurfaceCapabilitiesFullScreenExclusiveEXT>{ enum { value = true }; };
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  template <> struct isStructureChainValid<PhysicalDeviceSurfaceInfo2KHR, SurfaceFullScreenExclusiveInfoEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<SwapchainCreateInfoKHR, SurfaceFullScreenExclusiveInfoEXT>{ enum { value = true }; };
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  template <> struct isStructureChainValid<PhysicalDeviceSurfaceInfo2KHR, SurfaceFullScreenExclusiveWin32InfoEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<SwapchainCreateInfoKHR, SurfaceFullScreenExclusiveWin32InfoEXT>{ enum { value = true }; };
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+  template <> struct isStructureChainValid<SurfaceCapabilities2KHR, SurfaceProtectedCapabilitiesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<SwapchainCreateInfoKHR, SwapchainCounterCreateInfoEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<SwapchainCreateInfoKHR, SwapchainDisplayNativeHdrCreateInfoAMD>{ enum { value = true }; };
   template <> struct isStructureChainValid<ImageFormatProperties2, TextureLODGatherFormatPropertiesAMD>{ enum { value = true }; };
   template <> struct isStructureChainValid<InstanceCreateInfo, ValidationFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<InstanceCreateInfo, ValidationFlagsEXT>{ enum { value = true }; };
@@ -55029,6 +56574,9 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkCmdWriteTimestamp vkCmdWriteTimestamp = 0;
     PFN_vkEndCommandBuffer vkEndCommandBuffer = 0;
     PFN_vkResetCommandBuffer vkResetCommandBuffer = 0;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    PFN_vkAcquireFullScreenExclusiveModeEXT vkAcquireFullScreenExclusiveModeEXT = 0;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
     PFN_vkAcquireNextImage2KHR vkAcquireNextImage2KHR = 0;
     PFN_vkAcquireNextImageKHR vkAcquireNextImageKHR = 0;
     PFN_vkAllocateCommandBuffers vkAllocateCommandBuffers = 0;
@@ -55124,6 +56672,9 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkGetDeviceGroupPeerMemoryFeatures vkGetDeviceGroupPeerMemoryFeatures = 0;
     PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR vkGetDeviceGroupPeerMemoryFeaturesKHR = 0;
     PFN_vkGetDeviceGroupPresentCapabilitiesKHR vkGetDeviceGroupPresentCapabilitiesKHR = 0;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    PFN_vkGetDeviceGroupSurfacePresentModes2EXT vkGetDeviceGroupSurfacePresentModes2EXT = 0;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
     PFN_vkGetDeviceGroupSurfacePresentModesKHR vkGetDeviceGroupSurfacePresentModesKHR = 0;
     PFN_vkGetDeviceMemoryCommitment vkGetDeviceMemoryCommitment = 0;
     PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr = 0;
@@ -55189,14 +56740,19 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkRegisterDeviceEventEXT vkRegisterDeviceEventEXT = 0;
     PFN_vkRegisterDisplayEventEXT vkRegisterDisplayEventEXT = 0;
     PFN_vkRegisterObjectsNVX vkRegisterObjectsNVX = 0;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    PFN_vkReleaseFullScreenExclusiveModeEXT vkReleaseFullScreenExclusiveModeEXT = 0;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
     PFN_vkResetCommandPool vkResetCommandPool = 0;
     PFN_vkResetDescriptorPool vkResetDescriptorPool = 0;
     PFN_vkResetEvent vkResetEvent = 0;
     PFN_vkResetFences vkResetFences = 0;
+    PFN_vkResetQueryPoolEXT vkResetQueryPoolEXT = 0;
     PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = 0;
     PFN_vkSetDebugUtilsObjectTagEXT vkSetDebugUtilsObjectTagEXT = 0;
     PFN_vkSetEvent vkSetEvent = 0;
     PFN_vkSetHdrMetadataEXT vkSetHdrMetadataEXT = 0;
+    PFN_vkSetLocalDimmingAMD vkSetLocalDimmingAMD = 0;
     PFN_vkTrimCommandPool vkTrimCommandPool = 0;
     PFN_vkTrimCommandPoolKHR vkTrimCommandPoolKHR = 0;
     PFN_vkUnmapMemory vkUnmapMemory = 0;
@@ -55211,6 +56767,7 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT = 0;
     PFN_vkCreateDebugUtilsMessengerEXT vkCreateDebugUtilsMessengerEXT = 0;
     PFN_vkCreateDisplayPlaneSurfaceKHR vkCreateDisplayPlaneSurfaceKHR = 0;
+    PFN_vkCreateHeadlessSurfaceEXT vkCreateHeadlessSurfaceEXT = 0;
 #ifdef VK_USE_PLATFORM_IOS_MVK
     PFN_vkCreateIOSSurfaceMVK vkCreateIOSSurfaceMVK = 0;
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
@@ -55223,6 +56780,9 @@ namespace VULKAN_HPP_NAMESPACE
 #ifdef VK_USE_PLATFORM_METAL_EXT
     PFN_vkCreateMetalSurfaceEXT vkCreateMetalSurfaceEXT = 0;
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
+#ifdef VK_USE_PLATFORM_GGP
+    PFN_vkCreateStreamDescriptorSurfaceGGP vkCreateStreamDescriptorSurfaceGGP = 0;
+#endif /*VK_USE_PLATFORM_GGP*/
 #ifdef VK_USE_PLATFORM_VI_NN
     PFN_vkCreateViSurfaceNN vkCreateViSurfaceNN = 0;
 #endif /*VK_USE_PLATFORM_VI_NN*/
@@ -55297,11 +56857,15 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkGetPhysicalDeviceSparseImageFormatProperties vkGetPhysicalDeviceSparseImageFormatProperties = 0;
     PFN_vkGetPhysicalDeviceSparseImageFormatProperties2 vkGetPhysicalDeviceSparseImageFormatProperties2 = 0;
     PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR vkGetPhysicalDeviceSparseImageFormatProperties2KHR = 0;
+    PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = 0;
     PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT vkGetPhysicalDeviceSurfaceCapabilities2EXT = 0;
     PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR = 0;
     PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR vkGetPhysicalDeviceSurfaceCapabilitiesKHR = 0;
     PFN_vkGetPhysicalDeviceSurfaceFormats2KHR vkGetPhysicalDeviceSurfaceFormats2KHR = 0;
     PFN_vkGetPhysicalDeviceSurfaceFormatsKHR vkGetPhysicalDeviceSurfaceFormatsKHR = 0;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT vkGetPhysicalDeviceSurfacePresentModes2EXT = 0;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
     PFN_vkGetPhysicalDeviceSurfacePresentModesKHR vkGetPhysicalDeviceSurfacePresentModesKHR = 0;
     PFN_vkGetPhysicalDeviceSurfaceSupportKHR vkGetPhysicalDeviceSurfaceSupportKHR = 0;
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
@@ -55453,6 +57017,9 @@ namespace VULKAN_HPP_NAMESPACE
       vkCmdWriteTimestamp = PFN_vkCmdWriteTimestamp( device ? vkGetDeviceProcAddr( device, "vkCmdWriteTimestamp" ) : vkGetInstanceProcAddr( instance, "vkCmdWriteTimestamp" ) );
       vkEndCommandBuffer = PFN_vkEndCommandBuffer( device ? vkGetDeviceProcAddr( device, "vkEndCommandBuffer" ) : vkGetInstanceProcAddr( instance, "vkEndCommandBuffer" ) );
       vkResetCommandBuffer = PFN_vkResetCommandBuffer( device ? vkGetDeviceProcAddr( device, "vkResetCommandBuffer" ) : vkGetInstanceProcAddr( instance, "vkResetCommandBuffer" ) );
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+      vkAcquireFullScreenExclusiveModeEXT = PFN_vkAcquireFullScreenExclusiveModeEXT( device ? vkGetDeviceProcAddr( device, "vkAcquireFullScreenExclusiveModeEXT" ) : vkGetInstanceProcAddr( instance, "vkAcquireFullScreenExclusiveModeEXT" ) );
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkAcquireNextImage2KHR = PFN_vkAcquireNextImage2KHR( device ? vkGetDeviceProcAddr( device, "vkAcquireNextImage2KHR" ) : vkGetInstanceProcAddr( instance, "vkAcquireNextImage2KHR" ) );
       vkAcquireNextImageKHR = PFN_vkAcquireNextImageKHR( device ? vkGetDeviceProcAddr( device, "vkAcquireNextImageKHR" ) : vkGetInstanceProcAddr( instance, "vkAcquireNextImageKHR" ) );
       vkAllocateCommandBuffers = PFN_vkAllocateCommandBuffers( device ? vkGetDeviceProcAddr( device, "vkAllocateCommandBuffers" ) : vkGetInstanceProcAddr( instance, "vkAllocateCommandBuffers" ) );
@@ -55548,6 +57115,9 @@ namespace VULKAN_HPP_NAMESPACE
       vkGetDeviceGroupPeerMemoryFeatures = PFN_vkGetDeviceGroupPeerMemoryFeatures( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupPeerMemoryFeatures" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupPeerMemoryFeatures" ) );
       vkGetDeviceGroupPeerMemoryFeaturesKHR = PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupPeerMemoryFeaturesKHR" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupPeerMemoryFeaturesKHR" ) );
       vkGetDeviceGroupPresentCapabilitiesKHR = PFN_vkGetDeviceGroupPresentCapabilitiesKHR( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupPresentCapabilitiesKHR" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupPresentCapabilitiesKHR" ) );
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+      vkGetDeviceGroupSurfacePresentModes2EXT = PFN_vkGetDeviceGroupSurfacePresentModes2EXT( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupSurfacePresentModes2EXT" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupSurfacePresentModes2EXT" ) );
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkGetDeviceGroupSurfacePresentModesKHR = PFN_vkGetDeviceGroupSurfacePresentModesKHR( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupSurfacePresentModesKHR" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupSurfacePresentModesKHR" ) );
       vkGetDeviceMemoryCommitment = PFN_vkGetDeviceMemoryCommitment( device ? vkGetDeviceProcAddr( device, "vkGetDeviceMemoryCommitment" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceMemoryCommitment" ) );
       vkGetDeviceQueue = PFN_vkGetDeviceQueue( device ? vkGetDeviceProcAddr( device, "vkGetDeviceQueue" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceQueue" ) );
@@ -55612,14 +57182,19 @@ namespace VULKAN_HPP_NAMESPACE
       vkRegisterDeviceEventEXT = PFN_vkRegisterDeviceEventEXT( device ? vkGetDeviceProcAddr( device, "vkRegisterDeviceEventEXT" ) : vkGetInstanceProcAddr( instance, "vkRegisterDeviceEventEXT" ) );
       vkRegisterDisplayEventEXT = PFN_vkRegisterDisplayEventEXT( device ? vkGetDeviceProcAddr( device, "vkRegisterDisplayEventEXT" ) : vkGetInstanceProcAddr( instance, "vkRegisterDisplayEventEXT" ) );
       vkRegisterObjectsNVX = PFN_vkRegisterObjectsNVX( device ? vkGetDeviceProcAddr( device, "vkRegisterObjectsNVX" ) : vkGetInstanceProcAddr( instance, "vkRegisterObjectsNVX" ) );
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+      vkReleaseFullScreenExclusiveModeEXT = PFN_vkReleaseFullScreenExclusiveModeEXT( device ? vkGetDeviceProcAddr( device, "vkReleaseFullScreenExclusiveModeEXT" ) : vkGetInstanceProcAddr( instance, "vkReleaseFullScreenExclusiveModeEXT" ) );
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkResetCommandPool = PFN_vkResetCommandPool( device ? vkGetDeviceProcAddr( device, "vkResetCommandPool" ) : vkGetInstanceProcAddr( instance, "vkResetCommandPool" ) );
       vkResetDescriptorPool = PFN_vkResetDescriptorPool( device ? vkGetDeviceProcAddr( device, "vkResetDescriptorPool" ) : vkGetInstanceProcAddr( instance, "vkResetDescriptorPool" ) );
       vkResetEvent = PFN_vkResetEvent( device ? vkGetDeviceProcAddr( device, "vkResetEvent" ) : vkGetInstanceProcAddr( instance, "vkResetEvent" ) );
       vkResetFences = PFN_vkResetFences( device ? vkGetDeviceProcAddr( device, "vkResetFences" ) : vkGetInstanceProcAddr( instance, "vkResetFences" ) );
+      vkResetQueryPoolEXT = PFN_vkResetQueryPoolEXT( device ? vkGetDeviceProcAddr( device, "vkResetQueryPoolEXT" ) : vkGetInstanceProcAddr( instance, "vkResetQueryPoolEXT" ) );
       vkSetDebugUtilsObjectNameEXT = PFN_vkSetDebugUtilsObjectNameEXT( device ? vkGetDeviceProcAddr( device, "vkSetDebugUtilsObjectNameEXT" ) : vkGetInstanceProcAddr( instance, "vkSetDebugUtilsObjectNameEXT" ) );
       vkSetDebugUtilsObjectTagEXT = PFN_vkSetDebugUtilsObjectTagEXT( device ? vkGetDeviceProcAddr( device, "vkSetDebugUtilsObjectTagEXT" ) : vkGetInstanceProcAddr( instance, "vkSetDebugUtilsObjectTagEXT" ) );
       vkSetEvent = PFN_vkSetEvent( device ? vkGetDeviceProcAddr( device, "vkSetEvent" ) : vkGetInstanceProcAddr( instance, "vkSetEvent" ) );
       vkSetHdrMetadataEXT = PFN_vkSetHdrMetadataEXT( device ? vkGetDeviceProcAddr( device, "vkSetHdrMetadataEXT" ) : vkGetInstanceProcAddr( instance, "vkSetHdrMetadataEXT" ) );
+      vkSetLocalDimmingAMD = PFN_vkSetLocalDimmingAMD( device ? vkGetDeviceProcAddr( device, "vkSetLocalDimmingAMD" ) : vkGetInstanceProcAddr( instance, "vkSetLocalDimmingAMD" ) );
       vkTrimCommandPool = PFN_vkTrimCommandPool( device ? vkGetDeviceProcAddr( device, "vkTrimCommandPool" ) : vkGetInstanceProcAddr( instance, "vkTrimCommandPool" ) );
       vkTrimCommandPoolKHR = PFN_vkTrimCommandPoolKHR( device ? vkGetDeviceProcAddr( device, "vkTrimCommandPoolKHR" ) : vkGetInstanceProcAddr( instance, "vkTrimCommandPoolKHR" ) );
       vkUnmapMemory = PFN_vkUnmapMemory( device ? vkGetDeviceProcAddr( device, "vkUnmapMemory" ) : vkGetInstanceProcAddr( instance, "vkUnmapMemory" ) );
@@ -55634,6 +57209,7 @@ namespace VULKAN_HPP_NAMESPACE
       vkCreateDebugReportCallbackEXT = PFN_vkCreateDebugReportCallbackEXT( vkGetInstanceProcAddr( instance, "vkCreateDebugReportCallbackEXT" ) );
       vkCreateDebugUtilsMessengerEXT = PFN_vkCreateDebugUtilsMessengerEXT( vkGetInstanceProcAddr( instance, "vkCreateDebugUtilsMessengerEXT" ) );
       vkCreateDisplayPlaneSurfaceKHR = PFN_vkCreateDisplayPlaneSurfaceKHR( vkGetInstanceProcAddr( instance, "vkCreateDisplayPlaneSurfaceKHR" ) );
+      vkCreateHeadlessSurfaceEXT = PFN_vkCreateHeadlessSurfaceEXT( vkGetInstanceProcAddr( instance, "vkCreateHeadlessSurfaceEXT" ) );
 #ifdef VK_USE_PLATFORM_IOS_MVK
       vkCreateIOSSurfaceMVK = PFN_vkCreateIOSSurfaceMVK( vkGetInstanceProcAddr( instance, "vkCreateIOSSurfaceMVK" ) );
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
@@ -55646,6 +57222,9 @@ namespace VULKAN_HPP_NAMESPACE
 #ifdef VK_USE_PLATFORM_METAL_EXT
       vkCreateMetalSurfaceEXT = PFN_vkCreateMetalSurfaceEXT( vkGetInstanceProcAddr( instance, "vkCreateMetalSurfaceEXT" ) );
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
+#ifdef VK_USE_PLATFORM_GGP
+      vkCreateStreamDescriptorSurfaceGGP = PFN_vkCreateStreamDescriptorSurfaceGGP( vkGetInstanceProcAddr( instance, "vkCreateStreamDescriptorSurfaceGGP" ) );
+#endif /*VK_USE_PLATFORM_GGP*/
 #ifdef VK_USE_PLATFORM_VI_NN
       vkCreateViSurfaceNN = PFN_vkCreateViSurfaceNN( vkGetInstanceProcAddr( instance, "vkCreateViSurfaceNN" ) );
 #endif /*VK_USE_PLATFORM_VI_NN*/
@@ -55719,11 +57298,15 @@ namespace VULKAN_HPP_NAMESPACE
       vkGetPhysicalDeviceSparseImageFormatProperties = PFN_vkGetPhysicalDeviceSparseImageFormatProperties( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSparseImageFormatProperties" ) );
       vkGetPhysicalDeviceSparseImageFormatProperties2 = PFN_vkGetPhysicalDeviceSparseImageFormatProperties2( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSparseImageFormatProperties2" ) );
       vkGetPhysicalDeviceSparseImageFormatProperties2KHR = PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSparseImageFormatProperties2KHR" ) );
+      vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV" ) );
       vkGetPhysicalDeviceSurfaceCapabilities2EXT = PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceCapabilities2EXT" ) );
       vkGetPhysicalDeviceSurfaceCapabilities2KHR = PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceCapabilities2KHR" ) );
       vkGetPhysicalDeviceSurfaceCapabilitiesKHR = PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" ) );
       vkGetPhysicalDeviceSurfaceFormats2KHR = PFN_vkGetPhysicalDeviceSurfaceFormats2KHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceFormats2KHR" ) );
       vkGetPhysicalDeviceSurfaceFormatsKHR = PFN_vkGetPhysicalDeviceSurfaceFormatsKHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceFormatsKHR" ) );
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+      vkGetPhysicalDeviceSurfacePresentModes2EXT = PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfacePresentModes2EXT" ) );
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkGetPhysicalDeviceSurfacePresentModesKHR = PFN_vkGetPhysicalDeviceSurfacePresentModesKHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfacePresentModesKHR" ) );
       vkGetPhysicalDeviceSurfaceSupportKHR = PFN_vkGetPhysicalDeviceSurfaceSupportKHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceSupportKHR" ) );
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR

--- a/include/vulkan/vulkan.hpp
+++ b/include/vulkan/vulkan.hpp
@@ -56,7 +56,7 @@
 # define VULKAN_HPP_ASSERT   assert
 #endif
 
-static_assert( VK_HEADER_VERSION ==  107 , "Wrong VK_HEADER_VERSION!" );
+static_assert( VK_HEADER_VERSION ==  103 , "Wrong VK_HEADER_VERSION!" );
 
 // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
 // To enable this feature on 32-bit platforms please define VULKAN_HPP_TYPESAFE_CONVERSION
@@ -509,6 +509,9 @@ namespace VULKAN_HPP_NAMESPACE
   private:
     using Deleter = typename UniqueHandleTraits<Type,Dispatch>::deleter;
   public:
+
+    using element_type = Type;
+
     explicit UniqueHandle( Type const& value = Type(), Deleter const& deleter = Deleter() )
       : Deleter( deleter)
       , m_value( value )
@@ -1086,13 +1089,6 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkResetCommandBuffer( commandBuffer, flags );
     }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    VkResult vkAcquireFullScreenExclusiveModeEXT( VkDevice device, VkSwapchainKHR swapchain ) const
-    {
-      return ::vkAcquireFullScreenExclusiveModeEXT( device, swapchain );
-    }
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
     VkResult vkAcquireNextImage2KHR( VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex ) const
     {
       return ::vkAcquireNextImage2KHR( device, pAcquireInfo, pImageIndex );
@@ -1560,13 +1556,6 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkGetDeviceGroupPresentCapabilitiesKHR( device, pDeviceGroupPresentCapabilities );
     }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    VkResult vkGetDeviceGroupSurfacePresentModes2EXT( VkDevice device, const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, VkDeviceGroupPresentModeFlagsKHR* pModes ) const
-    {
-      return ::vkGetDeviceGroupSurfacePresentModes2EXT( device, pSurfaceInfo, pModes );
-    }
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
     VkResult vkGetDeviceGroupSurfacePresentModesKHR( VkDevice device, VkSurfaceKHR surface, VkDeviceGroupPresentModeFlagsKHR* pModes ) const
     {
       return ::vkGetDeviceGroupSurfacePresentModesKHR( device, surface, pModes );
@@ -1828,13 +1817,6 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkRegisterObjectsNVX( device, objectTable, objectCount, ppObjectTableEntries, pObjectIndices );
     }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    VkResult vkReleaseFullScreenExclusiveModeEXT( VkDevice device, VkSwapchainKHR swapchain ) const
-    {
-      return ::vkReleaseFullScreenExclusiveModeEXT( device, swapchain );
-    }
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
     VkResult vkResetCommandPool( VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags ) const
     {
       return ::vkResetCommandPool( device, commandPool, flags );
@@ -1855,11 +1837,6 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkResetFences( device, fenceCount, pFences );
     }
 
-    void vkResetQueryPoolEXT( VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount ) const
-    {
-      return ::vkResetQueryPoolEXT( device, queryPool, firstQuery, queryCount );
-    }
-
     VkResult vkSetDebugUtilsObjectNameEXT( VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo ) const
     {
       return ::vkSetDebugUtilsObjectNameEXT( device, pNameInfo );
@@ -1878,11 +1855,6 @@ namespace VULKAN_HPP_NAMESPACE
     void vkSetHdrMetadataEXT( VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR* pSwapchains, const VkHdrMetadataEXT* pMetadata ) const
     {
       return ::vkSetHdrMetadataEXT( device, swapchainCount, pSwapchains, pMetadata );
-    }
-
-    void vkSetLocalDimmingAMD( VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable ) const
-    {
-      return ::vkSetLocalDimmingAMD( device, swapChain, localDimmingEnable );
     }
 
     void vkTrimCommandPool( VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags ) const
@@ -1947,11 +1919,6 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkCreateDisplayPlaneSurfaceKHR( instance, pCreateInfo, pAllocator, pSurface );
     }
 
-    VkResult vkCreateHeadlessSurfaceEXT( VkInstance instance, const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface ) const
-    {
-      return ::vkCreateHeadlessSurfaceEXT( instance, pCreateInfo, pAllocator, pSurface );
-    }
-
 #ifdef VK_USE_PLATFORM_IOS_MVK
     VkResult vkCreateIOSSurfaceMVK( VkInstance instance, const VkIOSSurfaceCreateInfoMVK* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface ) const
     {
@@ -1979,13 +1946,6 @@ namespace VULKAN_HPP_NAMESPACE
       return ::vkCreateMetalSurfaceEXT( instance, pCreateInfo, pAllocator, pSurface );
     }
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
-
-#ifdef VK_USE_PLATFORM_GGP
-    VkResult vkCreateStreamDescriptorSurfaceGGP( VkInstance instance, const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface ) const
-    {
-      return ::vkCreateStreamDescriptorSurfaceGGP( instance, pCreateInfo, pAllocator, pSurface );
-    }
-#endif /*VK_USE_PLATFORM_GGP*/
 
 #ifdef VK_USE_PLATFORM_VI_NN
     VkResult vkCreateViSurfaceNN( VkInstance instance, const VkViSurfaceCreateInfoNN* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface ) const
@@ -2333,13 +2293,6 @@ namespace VULKAN_HPP_NAMESPACE
     {
       return ::vkGetPhysicalDeviceSurfaceFormatsKHR( physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats );
     }
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    VkResult vkGetPhysicalDeviceSurfacePresentModes2EXT( VkPhysicalDevice physicalDevice, const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes ) const
-    {
-      return ::vkGetPhysicalDeviceSurfacePresentModes2EXT( physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes );
-    }
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
     VkResult vkGetPhysicalDeviceSurfacePresentModesKHR( VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes ) const
     {
@@ -2871,7 +2824,6 @@ namespace VULKAN_HPP_NAMESPACE
     eAdobergbNonlinearEXT = VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT,
     ePassThroughEXT = VK_COLOR_SPACE_PASS_THROUGH_EXT,
     eExtendedSrgbNonlinearEXT = VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT,
-    eDisplayNativeAMD = VK_COLOR_SPACE_DISPLAY_NATIVE_AMD,
     eVkColorspaceSrgbNonlinear = VK_COLORSPACE_SRGB_NONLINEAR_KHR
   };
 
@@ -2894,7 +2846,6 @@ namespace VULKAN_HPP_NAMESPACE
       case ColorSpaceKHR::eAdobergbNonlinearEXT : return "AdobergbNonlinearEXT";
       case ColorSpaceKHR::ePassThroughEXT : return "PassThroughEXT";
       case ColorSpaceKHR::eExtendedSrgbNonlinearEXT : return "ExtendedSrgbNonlinearEXT";
-      case ColorSpaceKHR::eDisplayNativeAMD : return "DisplayNativeAMD";
       default: return "invalid";
     }
   }
@@ -3275,8 +3226,7 @@ namespace VULKAN_HPP_NAMESPACE
     eImaginationProprietary = VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR,
     eQualcommProprietary = VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR,
     eArmProprietary = VK_DRIVER_ID_ARM_PROPRIETARY_KHR,
-    eGooglePastel = VK_DRIVER_ID_GOOGLE_PASTEL_KHR,
-    eGgpProprietary = VK_DRIVER_ID_GGP_PROPRIETARY_KHR
+    eGooglePastel = VK_DRIVER_ID_GOOGLE_PASTEL_KHR
   };
 
   VULKAN_HPP_INLINE std::string to_string( DriverIdKHR value )
@@ -3293,7 +3243,6 @@ namespace VULKAN_HPP_NAMESPACE
       case DriverIdKHR::eQualcommProprietary : return "QualcommProprietary";
       case DriverIdKHR::eArmProprietary : return "ArmProprietary";
       case DriverIdKHR::eGooglePastel : return "GooglePastel";
-      case DriverIdKHR::eGgpProprietary : return "GgpProprietary";
       default: return "invalid";
     }
   }
@@ -3874,28 +3823,6 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid";
     }
   }
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  enum class FullScreenExclusiveEXT
-  {
-    eDefault = VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT,
-    eAllowed = VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT,
-    eDisallowed = VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT,
-    eApplicationControlled = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT
-  };
-
-  VULKAN_HPP_INLINE std::string to_string( FullScreenExclusiveEXT value )
-  {
-    switch ( value )
-    {
-      case FullScreenExclusiveEXT::eDefault : return "Default";
-      case FullScreenExclusiveEXT::eAllowed : return "Allowed";
-      case FullScreenExclusiveEXT::eDisallowed : return "Disallowed";
-      case FullScreenExclusiveEXT::eApplicationControlled : return "ApplicationControlled";
-      default: return "invalid";
-    }
-  }
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
   enum class GeometryTypeNV
   {
@@ -4512,7 +4439,6 @@ namespace VULKAN_HPP_NAMESPACE
     eErrorFragmentationEXT = VK_ERROR_FRAGMENTATION_EXT,
     eErrorNotPermittedEXT = VK_ERROR_NOT_PERMITTED_EXT,
     eErrorInvalidDeviceAddressEXT = VK_ERROR_INVALID_DEVICE_ADDRESS_EXT,
-    eErrorFullScreenExclusiveModeLostEXT = VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT,
     eErrorOutOfPoolMemoryKHR = VK_ERROR_OUT_OF_POOL_MEMORY_KHR,
     eErrorInvalidExternalHandleKHR = VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR
   };
@@ -4552,7 +4478,6 @@ namespace VULKAN_HPP_NAMESPACE
       case Result::eErrorFragmentationEXT : return "ErrorFragmentationEXT";
       case Result::eErrorNotPermittedEXT : return "ErrorNotPermittedEXT";
       case Result::eErrorInvalidDeviceAddressEXT : return "ErrorInvalidDeviceAddressEXT";
-      case Result::eErrorFullScreenExclusiveModeLostEXT : return "ErrorFullScreenExclusiveModeLostEXT";
       default: return "invalid";
     }
   }
@@ -4863,7 +4788,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRenderPassMultiviewCreateInfo = VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO,
     ePhysicalDeviceMultiviewFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES,
     ePhysicalDeviceMultiviewProperties = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES,
-    ePhysicalDeviceVariablePointersFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES,
+    ePhysicalDeviceVariablePointerFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES,
     eProtectedSubmitInfo = VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO,
     ePhysicalDeviceProtectedMemoryFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES,
     ePhysicalDeviceProtectedMemoryProperties = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES,
@@ -4891,7 +4816,7 @@ namespace VULKAN_HPP_NAMESPACE
     eExternalSemaphoreProperties = VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES,
     ePhysicalDeviceMaintenance3Properties = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES,
     eDescriptorSetLayoutSupport = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT,
-    ePhysicalDeviceShaderDrawParametersFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES,
+    ePhysicalDeviceShaderDrawParameterFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES,
     eSwapchainCreateInfoKHR = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
     ePresentInfoKHR = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
     eDeviceGroupPresentCapabilitiesKHR = VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR,
@@ -4921,7 +4846,6 @@ namespace VULKAN_HPP_NAMESPACE
     ePipelineRasterizationStateStreamCreateInfoEXT = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT,
     eImageViewHandleInfoNVX = VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX,
     eTextureLodGatherFormatPropertiesAMD = VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD,
-    eStreamDescriptorSurfaceCreateInfoGGP = VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP,
     ePhysicalDeviceCornerSampledImageFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV,
     eExternalMemoryImageCreateInfoNV = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV,
     eExportMemoryAllocateInfoNV = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV,
@@ -5069,8 +4993,6 @@ namespace VULKAN_HPP_NAMESPACE
     ePhysicalDeviceVertexAttributeDivisorPropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT,
     ePipelineVertexInputDivisorStateCreateInfoEXT = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT,
     ePhysicalDeviceVertexAttributeDivisorFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT,
-    ePresentFrameTokenGGP = VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP,
-    ePipelineCreationFeedbackCreateInfoEXT = VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT,
     ePhysicalDeviceDriverPropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR,
     ePhysicalDeviceFloatControlsPropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR,
     ePhysicalDeviceDepthStencilResolvePropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES_KHR,
@@ -5086,8 +5008,6 @@ namespace VULKAN_HPP_NAMESPACE
     eQueueFamilyCheckpointPropertiesNV = VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV,
     ePhysicalDeviceVulkanMemoryModelFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR,
     ePhysicalDevicePciBusInfoPropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT,
-    eDisplayNativeHdrSurfaceCapabilitiesAMD = VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD,
-    eSwapchainDisplayNativeHdrCreateInfoAMD = VK_STRUCTURE_TYPE_SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD,
     eImagepipeSurfaceCreateInfoFUCHSIA = VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA,
     eMetalSurfaceCreateInfoEXT = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT,
     ePhysicalDeviceFragmentDensityMapFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT,
@@ -5097,9 +5017,8 @@ namespace VULKAN_HPP_NAMESPACE
     ePhysicalDeviceMemoryBudgetPropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT,
     ePhysicalDeviceMemoryPriorityFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT,
     eMemoryPriorityAllocateInfoEXT = VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT,
-    eSurfaceProtectedCapabilitiesKHR = VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR,
     ePhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV,
-    ePhysicalDeviceBufferDeviceAddressFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT,
+    ePhysicalDeviceBufferAddressFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT,
     eBufferDeviceAddressInfoEXT = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_EXT,
     eBufferDeviceAddressCreateInfoEXT = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT,
     eImageStencilUsageCreateInfoEXT = VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO_EXT,
@@ -5108,13 +5027,6 @@ namespace VULKAN_HPP_NAMESPACE
     eCooperativeMatrixPropertiesNV = VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV,
     ePhysicalDeviceCooperativeMatrixPropertiesNV = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV,
     ePhysicalDeviceYcbcrImageArraysFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT,
-    eSurfaceFullScreenExclusiveInfoEXT = VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT,
-    eSurfaceCapabilitiesFullScreenExclusiveEXT = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT,
-    eSurfaceFullScreenExclusiveWin32InfoEXT = VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT,
-    eHeadlessSurfaceCreateInfoEXT = VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT,
-    ePhysicalDeviceHostQueryResetFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT,
-    ePhysicalDeviceVariablePointerFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES,
-    ePhysicalDeviceShaderDrawParameterFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES,
     eDebugReportCreateInfoEXT = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT,
     eRenderPassMultiviewCreateInfoKHR = VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO_KHR,
     ePhysicalDeviceMultiviewFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES_KHR,
@@ -5158,7 +5070,6 @@ namespace VULKAN_HPP_NAMESPACE
     eImageViewUsageCreateInfoKHR = VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO_KHR,
     ePipelineTessellationDomainOriginStateCreateInfoKHR = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO_KHR,
     ePhysicalDeviceVariablePointerFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR,
-    ePhysicalDeviceVariablePointersFeaturesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR,
     eMemoryDedicatedRequirementsKHR = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS_KHR,
     eMemoryDedicatedAllocateInfoKHR = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
     eBufferMemoryRequirementsInfo2KHR = VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR,
@@ -5175,8 +5086,7 @@ namespace VULKAN_HPP_NAMESPACE
     eBindBufferMemoryInfoKHR = VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO_KHR,
     eBindImageMemoryInfoKHR = VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHR,
     ePhysicalDeviceMaintenance3PropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES_KHR,
-    eDescriptorSetLayoutSupportKHR = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT_KHR,
-    ePhysicalDeviceBufferAddressFeaturesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT
+    eDescriptorSetLayoutSupportKHR = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT_KHR
   };
 
   VULKAN_HPP_INLINE std::string to_string( StructureType value )
@@ -5268,7 +5178,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eRenderPassMultiviewCreateInfo : return "RenderPassMultiviewCreateInfo";
       case StructureType::ePhysicalDeviceMultiviewFeatures : return "PhysicalDeviceMultiviewFeatures";
       case StructureType::ePhysicalDeviceMultiviewProperties : return "PhysicalDeviceMultiviewProperties";
-      case StructureType::ePhysicalDeviceVariablePointersFeatures : return "PhysicalDeviceVariablePointersFeatures";
+      case StructureType::ePhysicalDeviceVariablePointerFeatures : return "PhysicalDeviceVariablePointerFeatures";
       case StructureType::eProtectedSubmitInfo : return "ProtectedSubmitInfo";
       case StructureType::ePhysicalDeviceProtectedMemoryFeatures : return "PhysicalDeviceProtectedMemoryFeatures";
       case StructureType::ePhysicalDeviceProtectedMemoryProperties : return "PhysicalDeviceProtectedMemoryProperties";
@@ -5296,7 +5206,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eExternalSemaphoreProperties : return "ExternalSemaphoreProperties";
       case StructureType::ePhysicalDeviceMaintenance3Properties : return "PhysicalDeviceMaintenance3Properties";
       case StructureType::eDescriptorSetLayoutSupport : return "DescriptorSetLayoutSupport";
-      case StructureType::ePhysicalDeviceShaderDrawParametersFeatures : return "PhysicalDeviceShaderDrawParametersFeatures";
+      case StructureType::ePhysicalDeviceShaderDrawParameterFeatures : return "PhysicalDeviceShaderDrawParameterFeatures";
       case StructureType::eSwapchainCreateInfoKHR : return "SwapchainCreateInfoKHR";
       case StructureType::ePresentInfoKHR : return "PresentInfoKHR";
       case StructureType::eDeviceGroupPresentCapabilitiesKHR : return "DeviceGroupPresentCapabilitiesKHR";
@@ -5326,7 +5236,6 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePipelineRasterizationStateStreamCreateInfoEXT : return "PipelineRasterizationStateStreamCreateInfoEXT";
       case StructureType::eImageViewHandleInfoNVX : return "ImageViewHandleInfoNVX";
       case StructureType::eTextureLodGatherFormatPropertiesAMD : return "TextureLodGatherFormatPropertiesAMD";
-      case StructureType::eStreamDescriptorSurfaceCreateInfoGGP : return "StreamDescriptorSurfaceCreateInfoGGP";
       case StructureType::ePhysicalDeviceCornerSampledImageFeaturesNV : return "PhysicalDeviceCornerSampledImageFeaturesNV";
       case StructureType::eExternalMemoryImageCreateInfoNV : return "ExternalMemoryImageCreateInfoNV";
       case StructureType::eExportMemoryAllocateInfoNV : return "ExportMemoryAllocateInfoNV";
@@ -5474,8 +5383,6 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDeviceVertexAttributeDivisorPropertiesEXT : return "PhysicalDeviceVertexAttributeDivisorPropertiesEXT";
       case StructureType::ePipelineVertexInputDivisorStateCreateInfoEXT : return "PipelineVertexInputDivisorStateCreateInfoEXT";
       case StructureType::ePhysicalDeviceVertexAttributeDivisorFeaturesEXT : return "PhysicalDeviceVertexAttributeDivisorFeaturesEXT";
-      case StructureType::ePresentFrameTokenGGP : return "PresentFrameTokenGGP";
-      case StructureType::ePipelineCreationFeedbackCreateInfoEXT : return "PipelineCreationFeedbackCreateInfoEXT";
       case StructureType::ePhysicalDeviceDriverPropertiesKHR : return "PhysicalDeviceDriverPropertiesKHR";
       case StructureType::ePhysicalDeviceFloatControlsPropertiesKHR : return "PhysicalDeviceFloatControlsPropertiesKHR";
       case StructureType::ePhysicalDeviceDepthStencilResolvePropertiesKHR : return "PhysicalDeviceDepthStencilResolvePropertiesKHR";
@@ -5491,8 +5398,6 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eQueueFamilyCheckpointPropertiesNV : return "QueueFamilyCheckpointPropertiesNV";
       case StructureType::ePhysicalDeviceVulkanMemoryModelFeaturesKHR : return "PhysicalDeviceVulkanMemoryModelFeaturesKHR";
       case StructureType::ePhysicalDevicePciBusInfoPropertiesEXT : return "PhysicalDevicePciBusInfoPropertiesEXT";
-      case StructureType::eDisplayNativeHdrSurfaceCapabilitiesAMD : return "DisplayNativeHdrSurfaceCapabilitiesAMD";
-      case StructureType::eSwapchainDisplayNativeHdrCreateInfoAMD : return "SwapchainDisplayNativeHdrCreateInfoAMD";
       case StructureType::eImagepipeSurfaceCreateInfoFUCHSIA : return "ImagepipeSurfaceCreateInfoFUCHSIA";
       case StructureType::eMetalSurfaceCreateInfoEXT : return "MetalSurfaceCreateInfoEXT";
       case StructureType::ePhysicalDeviceFragmentDensityMapFeaturesEXT : return "PhysicalDeviceFragmentDensityMapFeaturesEXT";
@@ -5502,9 +5407,8 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDeviceMemoryBudgetPropertiesEXT : return "PhysicalDeviceMemoryBudgetPropertiesEXT";
       case StructureType::ePhysicalDeviceMemoryPriorityFeaturesEXT : return "PhysicalDeviceMemoryPriorityFeaturesEXT";
       case StructureType::eMemoryPriorityAllocateInfoEXT : return "MemoryPriorityAllocateInfoEXT";
-      case StructureType::eSurfaceProtectedCapabilitiesKHR : return "SurfaceProtectedCapabilitiesKHR";
       case StructureType::ePhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV : return "PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV";
-      case StructureType::ePhysicalDeviceBufferDeviceAddressFeaturesEXT : return "PhysicalDeviceBufferDeviceAddressFeaturesEXT";
+      case StructureType::ePhysicalDeviceBufferAddressFeaturesEXT : return "PhysicalDeviceBufferAddressFeaturesEXT";
       case StructureType::eBufferDeviceAddressInfoEXT : return "BufferDeviceAddressInfoEXT";
       case StructureType::eBufferDeviceAddressCreateInfoEXT : return "BufferDeviceAddressCreateInfoEXT";
       case StructureType::eImageStencilUsageCreateInfoEXT : return "ImageStencilUsageCreateInfoEXT";
@@ -5513,11 +5417,6 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eCooperativeMatrixPropertiesNV : return "CooperativeMatrixPropertiesNV";
       case StructureType::ePhysicalDeviceCooperativeMatrixPropertiesNV : return "PhysicalDeviceCooperativeMatrixPropertiesNV";
       case StructureType::ePhysicalDeviceYcbcrImageArraysFeaturesEXT : return "PhysicalDeviceYcbcrImageArraysFeaturesEXT";
-      case StructureType::eSurfaceFullScreenExclusiveInfoEXT : return "SurfaceFullScreenExclusiveInfoEXT";
-      case StructureType::eSurfaceCapabilitiesFullScreenExclusiveEXT : return "SurfaceCapabilitiesFullScreenExclusiveEXT";
-      case StructureType::eSurfaceFullScreenExclusiveWin32InfoEXT : return "SurfaceFullScreenExclusiveWin32InfoEXT";
-      case StructureType::eHeadlessSurfaceCreateInfoEXT : return "HeadlessSurfaceCreateInfoEXT";
-      case StructureType::ePhysicalDeviceHostQueryResetFeaturesEXT : return "PhysicalDeviceHostQueryResetFeaturesEXT";
       default: return "invalid";
     }
   }
@@ -7927,21 +7826,6 @@ namespace VULKAN_HPP_NAMESPACE
     return "{ " + result.substr(0, result.size() - 3) + " }";
   }
 
-  enum class HeadlessSurfaceCreateFlagBitsEXT
-  {};
-
-  VULKAN_HPP_INLINE std::string to_string( HeadlessSurfaceCreateFlagBitsEXT )
-  {
-    return "(void)";
-  }
-
-  using HeadlessSurfaceCreateFlagsEXT = Flags<HeadlessSurfaceCreateFlagBitsEXT, VkHeadlessSurfaceCreateFlagsEXT>;
-
-  VULKAN_HPP_INLINE std::string to_string( HeadlessSurfaceCreateFlagsEXT  )
-  {
-    return "{}";
-  }
-
 #ifdef VK_USE_PLATFORM_IOS_MVK
   enum class IOSSurfaceCreateFlagBitsMVK
   {};
@@ -8744,55 +8628,6 @@ namespace VULKAN_HPP_NAMESPACE
     if ( value & PipelineCreateFlagBits::eViewIndexFromDeviceIndex ) result += "ViewIndexFromDeviceIndex | ";
     if ( value & PipelineCreateFlagBits::eDispatchBase ) result += "DispatchBase | ";
     if ( value & PipelineCreateFlagBits::eDeferCompileNV ) result += "DeferCompileNV | ";
-    return "{ " + result.substr(0, result.size() - 3) + " }";
-  }
-
-  enum class PipelineCreationFeedbackFlagBitsEXT
-  {
-    eValid = VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT_EXT,
-    eApplicationPipelineCacheHit = VK_PIPELINE_CREATION_FEEDBACK_APPLICATION_PIPELINE_CACHE_HIT_BIT_EXT,
-    eBasePipelineAcceleration = VK_PIPELINE_CREATION_FEEDBACK_BASE_PIPELINE_ACCELERATION_BIT_EXT
-  };
-
-  VULKAN_HPP_INLINE std::string to_string( PipelineCreationFeedbackFlagBitsEXT value )
-  {
-    switch ( value )
-    {
-      case PipelineCreationFeedbackFlagBitsEXT::eValid : return "Valid";
-      case PipelineCreationFeedbackFlagBitsEXT::eApplicationPipelineCacheHit : return "ApplicationPipelineCacheHit";
-      case PipelineCreationFeedbackFlagBitsEXT::eBasePipelineAcceleration : return "BasePipelineAcceleration";
-      default: return "invalid";
-    }
-  }
-
-  using PipelineCreationFeedbackFlagsEXT = Flags<PipelineCreationFeedbackFlagBitsEXT, VkPipelineCreationFeedbackFlagsEXT>;
-
-  VULKAN_HPP_INLINE PipelineCreationFeedbackFlagsEXT operator|( PipelineCreationFeedbackFlagBitsEXT bit0, PipelineCreationFeedbackFlagBitsEXT bit1 )
-  {
-    return PipelineCreationFeedbackFlagsEXT( bit0 ) | bit1;
-  }
-
-  VULKAN_HPP_INLINE PipelineCreationFeedbackFlagsEXT operator~( PipelineCreationFeedbackFlagBitsEXT bits )
-  {
-    return ~( PipelineCreationFeedbackFlagsEXT( bits ) );
-  }
-
-  template <> struct FlagTraits<PipelineCreationFeedbackFlagBitsEXT>
-  {
-    enum
-    {
-      allFlags = VkFlags(PipelineCreationFeedbackFlagBitsEXT::eValid) | VkFlags(PipelineCreationFeedbackFlagBitsEXT::eApplicationPipelineCacheHit) | VkFlags(PipelineCreationFeedbackFlagBitsEXT::eBasePipelineAcceleration)
-    };
-  };
-
-  VULKAN_HPP_INLINE std::string to_string( PipelineCreationFeedbackFlagsEXT value  )
-  {
-    if ( !value ) return "{}";
-    std::string result;
-
-    if ( value & PipelineCreationFeedbackFlagBitsEXT::eValid ) result += "Valid | ";
-    if ( value & PipelineCreationFeedbackFlagBitsEXT::eApplicationPipelineCacheHit ) result += "ApplicationPipelineCacheHit | ";
-    if ( value & PipelineCreationFeedbackFlagBitsEXT::eBasePipelineAcceleration ) result += "BasePipelineAcceleration | ";
     return "{ " + result.substr(0, result.size() - 3) + " }";
   }
 
@@ -9859,23 +9694,6 @@ namespace VULKAN_HPP_NAMESPACE
     return "{ " + result.substr(0, result.size() - 3) + " }";
   }
 
-#ifdef VK_USE_PLATFORM_GGP
-  enum class StreamDescriptorSurfaceCreateFlagBitsGGP
-  {};
-
-  VULKAN_HPP_INLINE std::string to_string( StreamDescriptorSurfaceCreateFlagBitsGGP )
-  {
-    return "(void)";
-  }
-
-  using StreamDescriptorSurfaceCreateFlagsGGP = Flags<StreamDescriptorSurfaceCreateFlagBitsGGP, VkStreamDescriptorSurfaceCreateFlagsGGP>;
-
-  VULKAN_HPP_INLINE std::string to_string( StreamDescriptorSurfaceCreateFlagsGGP  )
-  {
-    return "{}";
-  }
-#endif /*VK_USE_PLATFORM_GGP*/
-
   enum class SubgroupFeatureFlagBits
   {
     eBasic = VK_SUBGROUP_FEATURE_BASIC_BIT,
@@ -10546,15 +10364,6 @@ namespace VULKAN_HPP_NAMESPACE
       : SystemError( make_error_code( Result::eErrorInvalidDeviceAddressEXT ), message ) {}
   };
 
-  class FullScreenExclusiveModeLostEXTError : public SystemError
-  {
-  public:
-    FullScreenExclusiveModeLostEXTError( std::string const& message )
-      : SystemError( make_error_code( Result::eErrorFullScreenExclusiveModeLostEXT ), message ) {}
-    FullScreenExclusiveModeLostEXTError( char const * message )
-      : SystemError( make_error_code( Result::eErrorFullScreenExclusiveModeLostEXT ), message ) {}
-  };
-
 
   VULKAN_HPP_INLINE void throwResultException( Result result, char const * message )
   {
@@ -10584,7 +10393,6 @@ namespace VULKAN_HPP_NAMESPACE
       case Result::eErrorFragmentationEXT: throw FragmentationEXTError( message );
       case Result::eErrorNotPermittedEXT: throw NotPermittedEXTError( message );
       case Result::eErrorInvalidDeviceAddressEXT: throw InvalidDeviceAddressEXTError( message );
-      case Result::eErrorFullScreenExclusiveModeLostEXT: throw FullScreenExclusiveModeLostEXTError( message );
       default: throw SystemError( make_error_code( result ) );
     }
   }
@@ -10836,7 +10644,6 @@ namespace VULKAN_HPP_NAMESPACE
   struct DisplayModeParametersKHR;
   struct DisplayModeProperties2KHR;
   struct DisplayModePropertiesKHR;
-  struct DisplayNativeHdrSurfaceCapabilitiesAMD;
   struct DisplayPlaneCapabilities2KHR;
   struct DisplayPlaneCapabilitiesKHR;
   struct DisplayPlaneInfo2KHR;
@@ -10910,7 +10717,6 @@ namespace VULKAN_HPP_NAMESPACE
   struct GeometryTrianglesNV;
   struct GraphicsPipelineCreateInfo;
   struct HdrMetadataEXT;
-  struct HeadlessSurfaceCreateInfoEXT;
 #ifdef VK_USE_PLATFORM_IOS_MVK
   struct IOSSurfaceCreateInfoMVK;
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
@@ -11021,8 +10827,7 @@ namespace VULKAN_HPP_NAMESPACE
   struct PhysicalDeviceASTCDecodeFeaturesEXT;
   struct PhysicalDeviceBlendOperationAdvancedFeaturesEXT;
   struct PhysicalDeviceBlendOperationAdvancedPropertiesEXT;
-  struct PhysicalDeviceBufferDeviceAddressFeaturesEXT;
-  using PhysicalDeviceBufferAddressFeaturesEXT = PhysicalDeviceBufferDeviceAddressFeaturesEXT;
+  struct PhysicalDeviceBufferAddressFeaturesEXT;
   struct PhysicalDeviceComputeShaderDerivativesFeaturesNV;
   struct PhysicalDeviceConditionalRenderingFeaturesEXT;
   struct PhysicalDeviceConservativeRasterizationPropertiesEXT;
@@ -11056,7 +10861,6 @@ namespace VULKAN_HPP_NAMESPACE
   struct PhysicalDeviceFragmentShaderBarycentricFeaturesNV;
   struct PhysicalDeviceGroupProperties;
   using PhysicalDeviceGroupPropertiesKHR = PhysicalDeviceGroupProperties;
-  struct PhysicalDeviceHostQueryResetFeaturesEXT;
   struct PhysicalDeviceIDProperties;
   using PhysicalDeviceIDPropertiesKHR = PhysicalDeviceIDProperties;
   struct PhysicalDeviceImageDrmFormatModifierInfoEXT;
@@ -11098,8 +10902,7 @@ namespace VULKAN_HPP_NAMESPACE
   struct PhysicalDeviceScalarBlockLayoutFeaturesEXT;
   struct PhysicalDeviceShaderAtomicInt64FeaturesKHR;
   struct PhysicalDeviceShaderCorePropertiesAMD;
-  struct PhysicalDeviceShaderDrawParametersFeatures;
-  using PhysicalDeviceShaderDrawParameterFeatures = PhysicalDeviceShaderDrawParametersFeatures;
+  struct PhysicalDeviceShaderDrawParameterFeatures;
   struct PhysicalDeviceShaderImageFootprintFeaturesNV;
   struct PhysicalDeviceShadingRateImageFeaturesNV;
   struct PhysicalDeviceShadingRateImagePropertiesNV;
@@ -11110,10 +10913,8 @@ namespace VULKAN_HPP_NAMESPACE
   struct PhysicalDeviceSurfaceInfo2KHR;
   struct PhysicalDeviceTransformFeedbackFeaturesEXT;
   struct PhysicalDeviceTransformFeedbackPropertiesEXT;
-  struct PhysicalDeviceVariablePointersFeatures;
-  using PhysicalDeviceVariablePointersFeaturesKHR = PhysicalDeviceVariablePointersFeatures;
-  using PhysicalDeviceVariablePointerFeaturesKHR = PhysicalDeviceVariablePointersFeatures;
-  using PhysicalDeviceVariablePointerFeatures = PhysicalDeviceVariablePointersFeatures;
+  struct PhysicalDeviceVariablePointerFeatures;
+  using PhysicalDeviceVariablePointerFeaturesKHR = PhysicalDeviceVariablePointerFeatures;
   struct PhysicalDeviceVertexAttributeDivisorFeaturesEXT;
   struct PhysicalDeviceVertexAttributeDivisorPropertiesEXT;
   struct PhysicalDeviceVulkanMemoryModelFeaturesKHR;
@@ -11124,8 +10925,6 @@ namespace VULKAN_HPP_NAMESPACE
   struct PipelineColorBlendStateCreateInfo;
   struct PipelineCoverageModulationStateCreateInfoNV;
   struct PipelineCoverageToColorStateCreateInfoNV;
-  struct PipelineCreationFeedbackCreateInfoEXT;
-  struct PipelineCreationFeedbackEXT;
   struct PipelineDepthStencilStateCreateInfo;
   struct PipelineDiscardRectangleStateCreateInfoEXT;
   struct PipelineDynamicStateCreateInfo;
@@ -11151,9 +10950,6 @@ namespace VULKAN_HPP_NAMESPACE
   struct PipelineViewportStateCreateInfo;
   struct PipelineViewportSwizzleStateCreateInfoNV;
   struct PipelineViewportWScalingStateCreateInfoNV;
-#ifdef VK_USE_PLATFORM_GGP
-  struct PresentFrameTokenGGP;
-#endif /*VK_USE_PLATFORM_GGP*/
   struct PresentInfoKHR;
   struct PresentRegionKHR;
   struct PresentRegionsKHR;
@@ -11215,9 +11011,6 @@ namespace VULKAN_HPP_NAMESPACE
   struct SpecializationInfo;
   struct SpecializationMapEntry;
   struct StencilOpState;
-#ifdef VK_USE_PLATFORM_GGP
-  struct StreamDescriptorSurfaceCreateInfoGGP;
-#endif /*VK_USE_PLATFORM_GGP*/
   struct SubmitInfo;
   struct SubpassBeginInfoKHR;
   struct SubpassDependency;
@@ -11230,22 +11023,11 @@ namespace VULKAN_HPP_NAMESPACE
   struct SubresourceLayout;
   struct SurfaceCapabilities2EXT;
   struct SurfaceCapabilities2KHR;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  struct SurfaceCapabilitiesFullScreenExclusiveEXT;
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
   struct SurfaceCapabilitiesKHR;
   struct SurfaceFormat2KHR;
   struct SurfaceFormatKHR;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  struct SurfaceFullScreenExclusiveInfoEXT;
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  struct SurfaceFullScreenExclusiveWin32InfoEXT;
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-  struct SurfaceProtectedCapabilitiesKHR;
   struct SwapchainCounterCreateInfoEXT;
   struct SwapchainCreateInfoKHR;
-  struct SwapchainDisplayNativeHdrCreateInfoAMD;
   struct TextureLODGatherFormatPropertiesAMD;
   struct ValidationCacheCreateInfoEXT;
   struct ValidationFeaturesEXT;
@@ -14009,16 +13791,6 @@ namespace VULKAN_HPP_NAMESPACE
       return m_device < rhs.m_device;
     }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    template<typename Dispatch = DispatchLoaderStatic>
-    Result acquireFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d = Dispatch() ) const;
-#else
-    template<typename Dispatch = DispatchLoaderStatic>
-    ResultValueType<void>::type acquireFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d = Dispatch() ) const;
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
     template<typename Dispatch = DispatchLoaderStatic>
     Result acquireNextImage2KHR( const AcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -15060,15 +14832,6 @@ namespace VULKAN_HPP_NAMESPACE
     ResultValueType<DeviceGroupPresentCapabilitiesKHR>::type getGroupPresentCapabilitiesKHR(Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    template<typename Dispatch = DispatchLoaderStatic>
-    Result getGroupSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, DeviceGroupPresentModeFlagsKHR* pModes, Dispatch const &d = Dispatch() ) const;
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    template<typename Dispatch = DispatchLoaderStatic>
-    ResultValueType<DeviceGroupPresentModeFlagsKHR>::type getGroupSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Dispatch const &d = Dispatch() ) const;
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
     template<typename Dispatch = DispatchLoaderStatic>
     Result getGroupSurfacePresentModesKHR( SurfaceKHR surface, DeviceGroupPresentModeFlagsKHR* pModes, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -15436,16 +15199,6 @@ namespace VULKAN_HPP_NAMESPACE
     ResultValueType<void>::type registerObjectsNVX( ObjectTableNVX objectTable, ArrayProxy<const ObjectTableEntryNVX* const> pObjectTableEntries, ArrayProxy<const uint32_t> objectIndices, Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    template<typename Dispatch = DispatchLoaderStatic>
-    Result releaseFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d = Dispatch() ) const;
-#else
-    template<typename Dispatch = DispatchLoaderStatic>
-    ResultValueType<void>::type releaseFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d = Dispatch() ) const;
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
 #ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template<typename Dispatch = DispatchLoaderStatic>
     Result resetCommandPool( CommandPool commandPool, CommandPoolResetFlags flags, Dispatch const &d = Dispatch() ) const;
@@ -15478,9 +15231,6 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     template<typename Dispatch = DispatchLoaderStatic>
-    void resetQueryPoolEXT( QueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, Dispatch const &d = Dispatch() ) const;
-
-    template<typename Dispatch = DispatchLoaderStatic>
     Result setDebugUtilsObjectNameEXT( const DebugUtilsObjectNameInfoEXT* pNameInfo, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template<typename Dispatch = DispatchLoaderStatic>
@@ -15508,9 +15258,6 @@ namespace VULKAN_HPP_NAMESPACE
     template<typename Dispatch = DispatchLoaderStatic>
     void setHdrMetadataEXT( ArrayProxy<const SwapchainKHR> swapchains, ArrayProxy<const HdrMetadataEXT> metadata, Dispatch const &d = Dispatch() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
-    template<typename Dispatch = DispatchLoaderStatic>
-    void setLocalDimmingAMD( SwapchainKHR swapChain, Bool32 localDimmingEnable, Dispatch const &d = Dispatch() ) const;
 
     template<typename Dispatch = DispatchLoaderStatic>
     void trimCommandPool( CommandPool commandPool, CommandPoolTrimFlags flags = CommandPoolTrimFlags(), Dispatch const &d = Dispatch() ) const;
@@ -16121,17 +15868,6 @@ namespace VULKAN_HPP_NAMESPACE
     typename ResultValueType<std::vector<SurfaceFormatKHR,Allocator>>::type getSurfaceFormatsKHR( SurfaceKHR surface, Allocator const& vectorAllocator, Dispatch const &d ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    template<typename Dispatch = DispatchLoaderStatic>
-    Result getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, uint32_t* pPresentModeCount, PresentModeKHR* pPresentModes, Dispatch const &d = Dispatch() ) const;
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    template<typename Allocator = std::allocator<PresentModeKHR>, typename Dispatch = DispatchLoaderStatic>
-    typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Dispatch const &d = Dispatch() ) const;
-    template<typename Allocator = std::allocator<PresentModeKHR>, typename Dispatch = DispatchLoaderStatic>
-    typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Allocator const& vectorAllocator, Dispatch const &d ) const;
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
     template<typename Dispatch = DispatchLoaderStatic>
     Result getSurfacePresentModesKHR( SurfaceKHR surface, uint32_t* pPresentModeCount, PresentModeKHR* pPresentModes, Dispatch const &d = Dispatch() ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -16317,17 +16053,6 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-    template<typename Dispatch = DispatchLoaderStatic>
-    Result createHeadlessSurfaceEXT( const HeadlessSurfaceCreateInfoEXT* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d = Dispatch() ) const;
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    template<typename Dispatch = DispatchLoaderStatic>
-    ResultValueType<SurfaceKHR>::type createHeadlessSurfaceEXT( const HeadlessSurfaceCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
-#ifndef VULKAN_HPP_NO_SMART_HANDLE
-    template<typename Dispatch = DispatchLoaderStatic>
-    typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type createHeadlessSurfaceEXTUnique( const HeadlessSurfaceCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
-#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
 #ifdef VK_USE_PLATFORM_IOS_MVK
     template<typename Dispatch = DispatchLoaderStatic>
     Result createIOSSurfaceMVK( const IOSSurfaceCreateInfoMVK* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d = Dispatch() ) const;
@@ -16379,19 +16104,6 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
-
-#ifdef VK_USE_PLATFORM_GGP
-    template<typename Dispatch = DispatchLoaderStatic>
-    Result createStreamDescriptorSurfaceGGP( const StreamDescriptorSurfaceCreateInfoGGP* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d = Dispatch() ) const;
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    template<typename Dispatch = DispatchLoaderStatic>
-    ResultValueType<SurfaceKHR>::type createStreamDescriptorSurfaceGGP( const StreamDescriptorSurfaceCreateInfoGGP & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
-#ifndef VULKAN_HPP_NO_SMART_HANDLE
-    template<typename Dispatch = DispatchLoaderStatic>
-    typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type createStreamDescriptorSurfaceGGPUnique( const StreamDescriptorSurfaceCreateInfoGGP & createInfo, Optional<const AllocationCallbacks> allocator = nullptr, Dispatch const &d = Dispatch() ) const;
-#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_GGP*/
 
 #ifdef VK_USE_PLATFORM_VI_NN
     template<typename Dispatch = DispatchLoaderStatic>
@@ -20164,7 +19876,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   struct BufferDeviceAddressCreateInfoEXT
   {
-    BufferDeviceAddressCreateInfoEXT( DeviceAddress deviceAddress_ = 0 )
+    BufferDeviceAddressCreateInfoEXT( DeviceSize deviceAddress_ = 0 )
       : deviceAddress( deviceAddress_ )
     {}
 
@@ -20185,7 +19897,7 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-    BufferDeviceAddressCreateInfoEXT & setDeviceAddress( DeviceAddress deviceAddress_ )
+    BufferDeviceAddressCreateInfoEXT & setDeviceAddress( DeviceSize deviceAddress_ )
     {
       deviceAddress = deviceAddress_;
       return *this;
@@ -20218,7 +19930,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   public:
     const void* pNext = nullptr;
-    DeviceAddress deviceAddress;
+    DeviceSize deviceAddress;
   };
   static_assert( sizeof( BufferDeviceAddressCreateInfoEXT ) == sizeof( VkBufferDeviceAddressCreateInfoEXT ), "struct and wrapper have different size!" );
 
@@ -26927,39 +26639,6 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DisplayModeProperties2KHR ) == sizeof( VkDisplayModeProperties2KHR ), "struct and wrapper have different size!" );
 
-  struct DisplayNativeHdrSurfaceCapabilitiesAMD
-  {
-    operator VkDisplayNativeHdrSurfaceCapabilitiesAMD const&() const
-    {
-      return *reinterpret_cast<const VkDisplayNativeHdrSurfaceCapabilitiesAMD*>( this );
-    }
-
-    operator VkDisplayNativeHdrSurfaceCapabilitiesAMD &()
-    {
-      return *reinterpret_cast<VkDisplayNativeHdrSurfaceCapabilitiesAMD*>( this );
-    }
-
-    bool operator==( DisplayNativeHdrSurfaceCapabilitiesAMD const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( localDimmingSupport == rhs.localDimmingSupport );
-    }
-
-    bool operator!=( DisplayNativeHdrSurfaceCapabilitiesAMD const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::eDisplayNativeHdrSurfaceCapabilitiesAMD;
-
-  public:
-    void* pNext = nullptr;
-    Bool32 localDimmingSupport;
-  };
-  static_assert( sizeof( DisplayNativeHdrSurfaceCapabilitiesAMD ) == sizeof( VkDisplayNativeHdrSurfaceCapabilitiesAMD ), "struct and wrapper have different size!" );
-
   struct DisplayPlaneCapabilitiesKHR
   {
     operator VkDisplayPlaneCapabilitiesKHR const&() const
@@ -31179,66 +30858,6 @@ namespace VULKAN_HPP_NAMESPACE
     float maxFrameAverageLightLevel;
   };
   static_assert( sizeof( HdrMetadataEXT ) == sizeof( VkHdrMetadataEXT ), "struct and wrapper have different size!" );
-
-  struct HeadlessSurfaceCreateInfoEXT
-  {
-    HeadlessSurfaceCreateInfoEXT( HeadlessSurfaceCreateFlagsEXT flags_ = HeadlessSurfaceCreateFlagsEXT() )
-      : flags( flags_ )
-    {}
-
-    HeadlessSurfaceCreateInfoEXT( VkHeadlessSurfaceCreateInfoEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( HeadlessSurfaceCreateInfoEXT ) );
-    }
-
-    HeadlessSurfaceCreateInfoEXT& operator=( VkHeadlessSurfaceCreateInfoEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( HeadlessSurfaceCreateInfoEXT ) );
-      return *this;
-    }
-
-    HeadlessSurfaceCreateInfoEXT & setPNext( const void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    HeadlessSurfaceCreateInfoEXT & setFlags( HeadlessSurfaceCreateFlagsEXT flags_ )
-    {
-      flags = flags_;
-      return *this;
-    }
-
-    operator VkHeadlessSurfaceCreateInfoEXT const&() const
-    {
-      return *reinterpret_cast<const VkHeadlessSurfaceCreateInfoEXT*>( this );
-    }
-
-    operator VkHeadlessSurfaceCreateInfoEXT &()
-    {
-      return *reinterpret_cast<VkHeadlessSurfaceCreateInfoEXT*>( this );
-    }
-
-    bool operator==( HeadlessSurfaceCreateInfoEXT const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( flags == rhs.flags );
-    }
-
-    bool operator!=( HeadlessSurfaceCreateInfoEXT const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::eHeadlessSurfaceCreateInfoEXT;
-
-  public:
-    const void* pNext = nullptr;
-    HeadlessSurfaceCreateFlagsEXT flags;
-  };
-  static_assert( sizeof( HeadlessSurfaceCreateInfoEXT ) == sizeof( VkHeadlessSurfaceCreateInfoEXT ), "struct and wrapper have different size!" );
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
   struct IOSSurfaceCreateInfoMVK
@@ -36105,62 +35724,62 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PhysicalDeviceBlendOperationAdvancedPropertiesEXT ) == sizeof( VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT ), "struct and wrapper have different size!" );
 
-  struct PhysicalDeviceBufferDeviceAddressFeaturesEXT
+  struct PhysicalDeviceBufferAddressFeaturesEXT
   {
-    PhysicalDeviceBufferDeviceAddressFeaturesEXT( Bool32 bufferDeviceAddress_ = 0,
-                                                  Bool32 bufferDeviceAddressCaptureReplay_ = 0,
-                                                  Bool32 bufferDeviceAddressMultiDevice_ = 0 )
+    PhysicalDeviceBufferAddressFeaturesEXT( Bool32 bufferDeviceAddress_ = 0,
+                                            Bool32 bufferDeviceAddressCaptureReplay_ = 0,
+                                            Bool32 bufferDeviceAddressMultiDevice_ = 0 )
       : bufferDeviceAddress( bufferDeviceAddress_ )
       , bufferDeviceAddressCaptureReplay( bufferDeviceAddressCaptureReplay_ )
       , bufferDeviceAddressMultiDevice( bufferDeviceAddressMultiDevice_ )
     {}
 
-    PhysicalDeviceBufferDeviceAddressFeaturesEXT( VkPhysicalDeviceBufferDeviceAddressFeaturesEXT const & rhs )
+    PhysicalDeviceBufferAddressFeaturesEXT( VkPhysicalDeviceBufferAddressFeaturesEXT const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceBufferDeviceAddressFeaturesEXT ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceBufferAddressFeaturesEXT ) );
     }
 
-    PhysicalDeviceBufferDeviceAddressFeaturesEXT& operator=( VkPhysicalDeviceBufferDeviceAddressFeaturesEXT const & rhs )
+    PhysicalDeviceBufferAddressFeaturesEXT& operator=( VkPhysicalDeviceBufferAddressFeaturesEXT const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceBufferDeviceAddressFeaturesEXT ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceBufferAddressFeaturesEXT ) );
       return *this;
     }
 
-    PhysicalDeviceBufferDeviceAddressFeaturesEXT & setPNext( void* pNext_ )
+    PhysicalDeviceBufferAddressFeaturesEXT & setPNext( void* pNext_ )
     {
       pNext = pNext_;
       return *this;
     }
 
-    PhysicalDeviceBufferDeviceAddressFeaturesEXT & setBufferDeviceAddress( Bool32 bufferDeviceAddress_ )
+    PhysicalDeviceBufferAddressFeaturesEXT & setBufferDeviceAddress( Bool32 bufferDeviceAddress_ )
     {
       bufferDeviceAddress = bufferDeviceAddress_;
       return *this;
     }
 
-    PhysicalDeviceBufferDeviceAddressFeaturesEXT & setBufferDeviceAddressCaptureReplay( Bool32 bufferDeviceAddressCaptureReplay_ )
+    PhysicalDeviceBufferAddressFeaturesEXT & setBufferDeviceAddressCaptureReplay( Bool32 bufferDeviceAddressCaptureReplay_ )
     {
       bufferDeviceAddressCaptureReplay = bufferDeviceAddressCaptureReplay_;
       return *this;
     }
 
-    PhysicalDeviceBufferDeviceAddressFeaturesEXT & setBufferDeviceAddressMultiDevice( Bool32 bufferDeviceAddressMultiDevice_ )
+    PhysicalDeviceBufferAddressFeaturesEXT & setBufferDeviceAddressMultiDevice( Bool32 bufferDeviceAddressMultiDevice_ )
     {
       bufferDeviceAddressMultiDevice = bufferDeviceAddressMultiDevice_;
       return *this;
     }
 
-    operator VkPhysicalDeviceBufferDeviceAddressFeaturesEXT const&() const
+    operator VkPhysicalDeviceBufferAddressFeaturesEXT const&() const
     {
-      return *reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>( this );
+      return *reinterpret_cast<const VkPhysicalDeviceBufferAddressFeaturesEXT*>( this );
     }
 
-    operator VkPhysicalDeviceBufferDeviceAddressFeaturesEXT &()
+    operator VkPhysicalDeviceBufferAddressFeaturesEXT &()
     {
-      return *reinterpret_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>( this );
+      return *reinterpret_cast<VkPhysicalDeviceBufferAddressFeaturesEXT*>( this );
     }
 
-    bool operator==( PhysicalDeviceBufferDeviceAddressFeaturesEXT const& rhs ) const
+    bool operator==( PhysicalDeviceBufferAddressFeaturesEXT const& rhs ) const
     {
       return ( sType == rhs.sType )
           && ( pNext == rhs.pNext )
@@ -36169,13 +35788,13 @@ namespace VULKAN_HPP_NAMESPACE
           && ( bufferDeviceAddressMultiDevice == rhs.bufferDeviceAddressMultiDevice );
     }
 
-    bool operator!=( PhysicalDeviceBufferDeviceAddressFeaturesEXT const& rhs ) const
+    bool operator!=( PhysicalDeviceBufferAddressFeaturesEXT const& rhs ) const
     {
       return !operator==( rhs );
     }
 
   private:
-    StructureType sType = StructureType::ePhysicalDeviceBufferDeviceAddressFeaturesEXT;
+    StructureType sType = StructureType::ePhysicalDeviceBufferAddressFeaturesEXT;
 
   public:
     void* pNext = nullptr;
@@ -36183,7 +35802,7 @@ namespace VULKAN_HPP_NAMESPACE
     Bool32 bufferDeviceAddressCaptureReplay;
     Bool32 bufferDeviceAddressMultiDevice;
   };
-  static_assert( sizeof( PhysicalDeviceBufferDeviceAddressFeaturesEXT ) == sizeof( VkPhysicalDeviceBufferDeviceAddressFeaturesEXT ), "struct and wrapper have different size!" );
+  static_assert( sizeof( PhysicalDeviceBufferAddressFeaturesEXT ) == sizeof( VkPhysicalDeviceBufferAddressFeaturesEXT ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceComputeShaderDerivativesFeaturesNV
   {
@@ -37813,66 +37432,6 @@ namespace VULKAN_HPP_NAMESPACE
     Bool32 subsetAllocation;
   };
   static_assert( sizeof( PhysicalDeviceGroupProperties ) == sizeof( VkPhysicalDeviceGroupProperties ), "struct and wrapper have different size!" );
-
-  struct PhysicalDeviceHostQueryResetFeaturesEXT
-  {
-    PhysicalDeviceHostQueryResetFeaturesEXT( Bool32 hostQueryReset_ = 0 )
-      : hostQueryReset( hostQueryReset_ )
-    {}
-
-    PhysicalDeviceHostQueryResetFeaturesEXT( VkPhysicalDeviceHostQueryResetFeaturesEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceHostQueryResetFeaturesEXT ) );
-    }
-
-    PhysicalDeviceHostQueryResetFeaturesEXT& operator=( VkPhysicalDeviceHostQueryResetFeaturesEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceHostQueryResetFeaturesEXT ) );
-      return *this;
-    }
-
-    PhysicalDeviceHostQueryResetFeaturesEXT & setPNext( void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    PhysicalDeviceHostQueryResetFeaturesEXT & setHostQueryReset( Bool32 hostQueryReset_ )
-    {
-      hostQueryReset = hostQueryReset_;
-      return *this;
-    }
-
-    operator VkPhysicalDeviceHostQueryResetFeaturesEXT const&() const
-    {
-      return *reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeaturesEXT*>( this );
-    }
-
-    operator VkPhysicalDeviceHostQueryResetFeaturesEXT &()
-    {
-      return *reinterpret_cast<VkPhysicalDeviceHostQueryResetFeaturesEXT*>( this );
-    }
-
-    bool operator==( PhysicalDeviceHostQueryResetFeaturesEXT const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( hostQueryReset == rhs.hostQueryReset );
-    }
-
-    bool operator!=( PhysicalDeviceHostQueryResetFeaturesEXT const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::ePhysicalDeviceHostQueryResetFeaturesEXT;
-
-  public:
-    void* pNext = nullptr;
-    Bool32 hostQueryReset;
-  };
-  static_assert( sizeof( PhysicalDeviceHostQueryResetFeaturesEXT ) == sizeof( VkPhysicalDeviceHostQueryResetFeaturesEXT ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceIDProperties
   {
@@ -39721,65 +39280,65 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PhysicalDeviceShaderCorePropertiesAMD ) == sizeof( VkPhysicalDeviceShaderCorePropertiesAMD ), "struct and wrapper have different size!" );
 
-  struct PhysicalDeviceShaderDrawParametersFeatures
+  struct PhysicalDeviceShaderDrawParameterFeatures
   {
-    PhysicalDeviceShaderDrawParametersFeatures( Bool32 shaderDrawParameters_ = 0 )
+    PhysicalDeviceShaderDrawParameterFeatures( Bool32 shaderDrawParameters_ = 0 )
       : shaderDrawParameters( shaderDrawParameters_ )
     {}
 
-    PhysicalDeviceShaderDrawParametersFeatures( VkPhysicalDeviceShaderDrawParametersFeatures const & rhs )
+    PhysicalDeviceShaderDrawParameterFeatures( VkPhysicalDeviceShaderDrawParameterFeatures const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderDrawParametersFeatures ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderDrawParameterFeatures ) );
     }
 
-    PhysicalDeviceShaderDrawParametersFeatures& operator=( VkPhysicalDeviceShaderDrawParametersFeatures const & rhs )
+    PhysicalDeviceShaderDrawParameterFeatures& operator=( VkPhysicalDeviceShaderDrawParameterFeatures const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderDrawParametersFeatures ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceShaderDrawParameterFeatures ) );
       return *this;
     }
 
-    PhysicalDeviceShaderDrawParametersFeatures & setPNext( void* pNext_ )
+    PhysicalDeviceShaderDrawParameterFeatures & setPNext( void* pNext_ )
     {
       pNext = pNext_;
       return *this;
     }
 
-    PhysicalDeviceShaderDrawParametersFeatures & setShaderDrawParameters( Bool32 shaderDrawParameters_ )
+    PhysicalDeviceShaderDrawParameterFeatures & setShaderDrawParameters( Bool32 shaderDrawParameters_ )
     {
       shaderDrawParameters = shaderDrawParameters_;
       return *this;
     }
 
-    operator VkPhysicalDeviceShaderDrawParametersFeatures const&() const
+    operator VkPhysicalDeviceShaderDrawParameterFeatures const&() const
     {
-      return *reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>( this );
+      return *reinterpret_cast<const VkPhysicalDeviceShaderDrawParameterFeatures*>( this );
     }
 
-    operator VkPhysicalDeviceShaderDrawParametersFeatures &()
+    operator VkPhysicalDeviceShaderDrawParameterFeatures &()
     {
-      return *reinterpret_cast<VkPhysicalDeviceShaderDrawParametersFeatures*>( this );
+      return *reinterpret_cast<VkPhysicalDeviceShaderDrawParameterFeatures*>( this );
     }
 
-    bool operator==( PhysicalDeviceShaderDrawParametersFeatures const& rhs ) const
+    bool operator==( PhysicalDeviceShaderDrawParameterFeatures const& rhs ) const
     {
       return ( sType == rhs.sType )
           && ( pNext == rhs.pNext )
           && ( shaderDrawParameters == rhs.shaderDrawParameters );
     }
 
-    bool operator!=( PhysicalDeviceShaderDrawParametersFeatures const& rhs ) const
+    bool operator!=( PhysicalDeviceShaderDrawParameterFeatures const& rhs ) const
     {
       return !operator==( rhs );
     }
 
   private:
-    StructureType sType = StructureType::ePhysicalDeviceShaderDrawParametersFeatures;
+    StructureType sType = StructureType::ePhysicalDeviceShaderDrawParameterFeatures;
 
   public:
     void* pNext = nullptr;
     Bool32 shaderDrawParameters;
   };
-  static_assert( sizeof( PhysicalDeviceShaderDrawParametersFeatures ) == sizeof( VkPhysicalDeviceShaderDrawParametersFeatures ), "struct and wrapper have different size!" );
+  static_assert( sizeof( PhysicalDeviceShaderDrawParameterFeatures ) == sizeof( VkPhysicalDeviceShaderDrawParameterFeatures ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceShaderImageFootprintFeaturesNV
   {
@@ -40268,54 +39827,54 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PhysicalDeviceTransformFeedbackPropertiesEXT ) == sizeof( VkPhysicalDeviceTransformFeedbackPropertiesEXT ), "struct and wrapper have different size!" );
 
-  struct PhysicalDeviceVariablePointersFeatures
+  struct PhysicalDeviceVariablePointerFeatures
   {
-    PhysicalDeviceVariablePointersFeatures( Bool32 variablePointersStorageBuffer_ = 0,
-                                            Bool32 variablePointers_ = 0 )
+    PhysicalDeviceVariablePointerFeatures( Bool32 variablePointersStorageBuffer_ = 0,
+                                           Bool32 variablePointers_ = 0 )
       : variablePointersStorageBuffer( variablePointersStorageBuffer_ )
       , variablePointers( variablePointers_ )
     {}
 
-    PhysicalDeviceVariablePointersFeatures( VkPhysicalDeviceVariablePointersFeatures const & rhs )
+    PhysicalDeviceVariablePointerFeatures( VkPhysicalDeviceVariablePointerFeatures const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceVariablePointersFeatures ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceVariablePointerFeatures ) );
     }
 
-    PhysicalDeviceVariablePointersFeatures& operator=( VkPhysicalDeviceVariablePointersFeatures const & rhs )
+    PhysicalDeviceVariablePointerFeatures& operator=( VkPhysicalDeviceVariablePointerFeatures const & rhs )
     {
-      memcpy( this, &rhs, sizeof( PhysicalDeviceVariablePointersFeatures ) );
+      memcpy( this, &rhs, sizeof( PhysicalDeviceVariablePointerFeatures ) );
       return *this;
     }
 
-    PhysicalDeviceVariablePointersFeatures & setPNext( void* pNext_ )
+    PhysicalDeviceVariablePointerFeatures & setPNext( void* pNext_ )
     {
       pNext = pNext_;
       return *this;
     }
 
-    PhysicalDeviceVariablePointersFeatures & setVariablePointersStorageBuffer( Bool32 variablePointersStorageBuffer_ )
+    PhysicalDeviceVariablePointerFeatures & setVariablePointersStorageBuffer( Bool32 variablePointersStorageBuffer_ )
     {
       variablePointersStorageBuffer = variablePointersStorageBuffer_;
       return *this;
     }
 
-    PhysicalDeviceVariablePointersFeatures & setVariablePointers( Bool32 variablePointers_ )
+    PhysicalDeviceVariablePointerFeatures & setVariablePointers( Bool32 variablePointers_ )
     {
       variablePointers = variablePointers_;
       return *this;
     }
 
-    operator VkPhysicalDeviceVariablePointersFeatures const&() const
+    operator VkPhysicalDeviceVariablePointerFeatures const&() const
     {
-      return *reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>( this );
+      return *reinterpret_cast<const VkPhysicalDeviceVariablePointerFeatures*>( this );
     }
 
-    operator VkPhysicalDeviceVariablePointersFeatures &()
+    operator VkPhysicalDeviceVariablePointerFeatures &()
     {
-      return *reinterpret_cast<VkPhysicalDeviceVariablePointersFeatures*>( this );
+      return *reinterpret_cast<VkPhysicalDeviceVariablePointerFeatures*>( this );
     }
 
-    bool operator==( PhysicalDeviceVariablePointersFeatures const& rhs ) const
+    bool operator==( PhysicalDeviceVariablePointerFeatures const& rhs ) const
     {
       return ( sType == rhs.sType )
           && ( pNext == rhs.pNext )
@@ -40323,20 +39882,20 @@ namespace VULKAN_HPP_NAMESPACE
           && ( variablePointers == rhs.variablePointers );
     }
 
-    bool operator!=( PhysicalDeviceVariablePointersFeatures const& rhs ) const
+    bool operator!=( PhysicalDeviceVariablePointerFeatures const& rhs ) const
     {
       return !operator==( rhs );
     }
 
   private:
-    StructureType sType = StructureType::ePhysicalDeviceVariablePointersFeatures;
+    StructureType sType = StructureType::ePhysicalDeviceVariablePointerFeatures;
 
   public:
     void* pNext = nullptr;
     Bool32 variablePointersStorageBuffer;
     Bool32 variablePointers;
   };
-  static_assert( sizeof( PhysicalDeviceVariablePointersFeatures ) == sizeof( VkPhysicalDeviceVariablePointersFeatures ), "struct and wrapper have different size!" );
+  static_assert( sizeof( PhysicalDeviceVariablePointerFeatures ) == sizeof( VkPhysicalDeviceVariablePointerFeatures ), "struct and wrapper have different size!" );
 
   struct PhysicalDeviceVertexAttributeDivisorFeaturesEXT
   {
@@ -40920,114 +40479,6 @@ namespace VULKAN_HPP_NAMESPACE
     uint32_t coverageToColorLocation;
   };
   static_assert( sizeof( PipelineCoverageToColorStateCreateInfoNV ) == sizeof( VkPipelineCoverageToColorStateCreateInfoNV ), "struct and wrapper have different size!" );
-
-  struct PipelineCreationFeedbackEXT
-  {
-    operator VkPipelineCreationFeedbackEXT const&() const
-    {
-      return *reinterpret_cast<const VkPipelineCreationFeedbackEXT*>( this );
-    }
-
-    operator VkPipelineCreationFeedbackEXT &()
-    {
-      return *reinterpret_cast<VkPipelineCreationFeedbackEXT*>( this );
-    }
-
-    bool operator==( PipelineCreationFeedbackEXT const& rhs ) const
-    {
-      return ( flags == rhs.flags )
-          && ( duration == rhs.duration );
-    }
-
-    bool operator!=( PipelineCreationFeedbackEXT const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-    PipelineCreationFeedbackFlagsEXT flags;
-    uint64_t duration;
-  };
-  static_assert( sizeof( PipelineCreationFeedbackEXT ) == sizeof( VkPipelineCreationFeedbackEXT ), "struct and wrapper have different size!" );
-
-  struct PipelineCreationFeedbackCreateInfoEXT
-  {
-    PipelineCreationFeedbackCreateInfoEXT( PipelineCreationFeedbackEXT* pPipelineCreationFeedback_ = nullptr,
-                                           uint32_t pipelineStageCreationFeedbackCount_ = 0,
-                                           PipelineCreationFeedbackEXT* pPipelineStageCreationFeedbacks_ = nullptr )
-      : pPipelineCreationFeedback( pPipelineCreationFeedback_ )
-      , pipelineStageCreationFeedbackCount( pipelineStageCreationFeedbackCount_ )
-      , pPipelineStageCreationFeedbacks( pPipelineStageCreationFeedbacks_ )
-    {}
-
-    PipelineCreationFeedbackCreateInfoEXT( VkPipelineCreationFeedbackCreateInfoEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( PipelineCreationFeedbackCreateInfoEXT ) );
-    }
-
-    PipelineCreationFeedbackCreateInfoEXT& operator=( VkPipelineCreationFeedbackCreateInfoEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( PipelineCreationFeedbackCreateInfoEXT ) );
-      return *this;
-    }
-
-    PipelineCreationFeedbackCreateInfoEXT & setPNext( const void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    PipelineCreationFeedbackCreateInfoEXT & setPPipelineCreationFeedback( PipelineCreationFeedbackEXT* pPipelineCreationFeedback_ )
-    {
-      pPipelineCreationFeedback = pPipelineCreationFeedback_;
-      return *this;
-    }
-
-    PipelineCreationFeedbackCreateInfoEXT & setPipelineStageCreationFeedbackCount( uint32_t pipelineStageCreationFeedbackCount_ )
-    {
-      pipelineStageCreationFeedbackCount = pipelineStageCreationFeedbackCount_;
-      return *this;
-    }
-
-    PipelineCreationFeedbackCreateInfoEXT & setPPipelineStageCreationFeedbacks( PipelineCreationFeedbackEXT* pPipelineStageCreationFeedbacks_ )
-    {
-      pPipelineStageCreationFeedbacks = pPipelineStageCreationFeedbacks_;
-      return *this;
-    }
-
-    operator VkPipelineCreationFeedbackCreateInfoEXT const&() const
-    {
-      return *reinterpret_cast<const VkPipelineCreationFeedbackCreateInfoEXT*>( this );
-    }
-
-    operator VkPipelineCreationFeedbackCreateInfoEXT &()
-    {
-      return *reinterpret_cast<VkPipelineCreationFeedbackCreateInfoEXT*>( this );
-    }
-
-    bool operator==( PipelineCreationFeedbackCreateInfoEXT const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( pPipelineCreationFeedback == rhs.pPipelineCreationFeedback )
-          && ( pipelineStageCreationFeedbackCount == rhs.pipelineStageCreationFeedbackCount )
-          && ( pPipelineStageCreationFeedbacks == rhs.pPipelineStageCreationFeedbacks );
-    }
-
-    bool operator!=( PipelineCreationFeedbackCreateInfoEXT const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::ePipelineCreationFeedbackCreateInfoEXT;
-
-  public:
-    const void* pNext = nullptr;
-    PipelineCreationFeedbackEXT* pPipelineCreationFeedback;
-    uint32_t pipelineStageCreationFeedbackCount;
-    PipelineCreationFeedbackEXT* pPipelineStageCreationFeedbacks;
-  };
-  static_assert( sizeof( PipelineCreationFeedbackCreateInfoEXT ) == sizeof( VkPipelineCreationFeedbackCreateInfoEXT ), "struct and wrapper have different size!" );
 
   struct PipelineDiscardRectangleStateCreateInfoEXT
   {
@@ -42463,68 +41914,6 @@ namespace VULKAN_HPP_NAMESPACE
     const ViewportWScalingNV* pViewportWScalings;
   };
   static_assert( sizeof( PipelineViewportWScalingStateCreateInfoNV ) == sizeof( VkPipelineViewportWScalingStateCreateInfoNV ), "struct and wrapper have different size!" );
-
-#ifdef VK_USE_PLATFORM_GGP
-  struct PresentFrameTokenGGP
-  {
-    PresentFrameTokenGGP( GgpFrameToken frameToken_ = 0 )
-      : frameToken( frameToken_ )
-    {}
-
-    PresentFrameTokenGGP( VkPresentFrameTokenGGP const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( PresentFrameTokenGGP ) );
-    }
-
-    PresentFrameTokenGGP& operator=( VkPresentFrameTokenGGP const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( PresentFrameTokenGGP ) );
-      return *this;
-    }
-
-    PresentFrameTokenGGP & setPNext( const void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    PresentFrameTokenGGP & setFrameToken( GgpFrameToken frameToken_ )
-    {
-      frameToken = frameToken_;
-      return *this;
-    }
-
-    operator VkPresentFrameTokenGGP const&() const
-    {
-      return *reinterpret_cast<const VkPresentFrameTokenGGP*>( this );
-    }
-
-    operator VkPresentFrameTokenGGP &()
-    {
-      return *reinterpret_cast<VkPresentFrameTokenGGP*>( this );
-    }
-
-    bool operator==( PresentFrameTokenGGP const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( frameToken == rhs.frameToken );
-    }
-
-    bool operator!=( PresentFrameTokenGGP const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::ePresentFrameTokenGGP;
-
-  public:
-    const void* pNext = nullptr;
-    GgpFrameToken frameToken;
-  };
-  static_assert( sizeof( PresentFrameTokenGGP ) == sizeof( VkPresentFrameTokenGGP ), "struct and wrapper have different size!" );
-#endif /*VK_USE_PLATFORM_GGP*/
 
   struct PresentInfoKHR
   {
@@ -45829,78 +45218,6 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( SparseImageMemoryRequirements2 ) == sizeof( VkSparseImageMemoryRequirements2 ), "struct and wrapper have different size!" );
 
-#ifdef VK_USE_PLATFORM_GGP
-  struct StreamDescriptorSurfaceCreateInfoGGP
-  {
-    StreamDescriptorSurfaceCreateInfoGGP( StreamDescriptorSurfaceCreateFlagsGGP flags_ = StreamDescriptorSurfaceCreateFlagsGGP(),
-                                          GgpStreamDescriptor streamDescriptor_ = 0 )
-      : flags( flags_ )
-      , streamDescriptor( streamDescriptor_ )
-    {}
-
-    StreamDescriptorSurfaceCreateInfoGGP( VkStreamDescriptorSurfaceCreateInfoGGP const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( StreamDescriptorSurfaceCreateInfoGGP ) );
-    }
-
-    StreamDescriptorSurfaceCreateInfoGGP& operator=( VkStreamDescriptorSurfaceCreateInfoGGP const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( StreamDescriptorSurfaceCreateInfoGGP ) );
-      return *this;
-    }
-
-    StreamDescriptorSurfaceCreateInfoGGP & setPNext( const void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    StreamDescriptorSurfaceCreateInfoGGP & setFlags( StreamDescriptorSurfaceCreateFlagsGGP flags_ )
-    {
-      flags = flags_;
-      return *this;
-    }
-
-    StreamDescriptorSurfaceCreateInfoGGP & setStreamDescriptor( GgpStreamDescriptor streamDescriptor_ )
-    {
-      streamDescriptor = streamDescriptor_;
-      return *this;
-    }
-
-    operator VkStreamDescriptorSurfaceCreateInfoGGP const&() const
-    {
-      return *reinterpret_cast<const VkStreamDescriptorSurfaceCreateInfoGGP*>( this );
-    }
-
-    operator VkStreamDescriptorSurfaceCreateInfoGGP &()
-    {
-      return *reinterpret_cast<VkStreamDescriptorSurfaceCreateInfoGGP*>( this );
-    }
-
-    bool operator==( StreamDescriptorSurfaceCreateInfoGGP const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( flags == rhs.flags )
-          && ( streamDescriptor == rhs.streamDescriptor );
-    }
-
-    bool operator!=( StreamDescriptorSurfaceCreateInfoGGP const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::eStreamDescriptorSurfaceCreateInfoGGP;
-
-  public:
-    const void* pNext = nullptr;
-    StreamDescriptorSurfaceCreateFlagsGGP flags;
-    GgpStreamDescriptor streamDescriptor;
-  };
-  static_assert( sizeof( StreamDescriptorSurfaceCreateInfoGGP ) == sizeof( VkStreamDescriptorSurfaceCreateInfoGGP ), "struct and wrapper have different size!" );
-#endif /*VK_USE_PLATFORM_GGP*/
-
   struct SubmitInfo
   {
     SubmitInfo( uint32_t waitSemaphoreCount_ = 0,
@@ -46342,68 +45659,6 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( SurfaceCapabilities2KHR ) == sizeof( VkSurfaceCapabilities2KHR ), "struct and wrapper have different size!" );
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  struct SurfaceCapabilitiesFullScreenExclusiveEXT
-  {
-    SurfaceCapabilitiesFullScreenExclusiveEXT( Bool32 fullScreenExclusiveSupported_ = 0 )
-      : fullScreenExclusiveSupported( fullScreenExclusiveSupported_ )
-    {}
-
-    SurfaceCapabilitiesFullScreenExclusiveEXT( VkSurfaceCapabilitiesFullScreenExclusiveEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SurfaceCapabilitiesFullScreenExclusiveEXT ) );
-    }
-
-    SurfaceCapabilitiesFullScreenExclusiveEXT& operator=( VkSurfaceCapabilitiesFullScreenExclusiveEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SurfaceCapabilitiesFullScreenExclusiveEXT ) );
-      return *this;
-    }
-
-    SurfaceCapabilitiesFullScreenExclusiveEXT & setPNext( void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    SurfaceCapabilitiesFullScreenExclusiveEXT & setFullScreenExclusiveSupported( Bool32 fullScreenExclusiveSupported_ )
-    {
-      fullScreenExclusiveSupported = fullScreenExclusiveSupported_;
-      return *this;
-    }
-
-    operator VkSurfaceCapabilitiesFullScreenExclusiveEXT const&() const
-    {
-      return *reinterpret_cast<const VkSurfaceCapabilitiesFullScreenExclusiveEXT*>( this );
-    }
-
-    operator VkSurfaceCapabilitiesFullScreenExclusiveEXT &()
-    {
-      return *reinterpret_cast<VkSurfaceCapabilitiesFullScreenExclusiveEXT*>( this );
-    }
-
-    bool operator==( SurfaceCapabilitiesFullScreenExclusiveEXT const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( fullScreenExclusiveSupported == rhs.fullScreenExclusiveSupported );
-    }
-
-    bool operator!=( SurfaceCapabilitiesFullScreenExclusiveEXT const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::eSurfaceCapabilitiesFullScreenExclusiveEXT;
-
-  public:
-    void* pNext = nullptr;
-    Bool32 fullScreenExclusiveSupported;
-  };
-  static_assert( sizeof( SurfaceCapabilitiesFullScreenExclusiveEXT ) == sizeof( VkSurfaceCapabilitiesFullScreenExclusiveEXT ), "struct and wrapper have different size!" );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
   struct SurfaceFormatKHR
   {
     operator VkSurfaceFormatKHR const&() const
@@ -46464,190 +45719,6 @@ namespace VULKAN_HPP_NAMESPACE
     SurfaceFormatKHR surfaceFormat;
   };
   static_assert( sizeof( SurfaceFormat2KHR ) == sizeof( VkSurfaceFormat2KHR ), "struct and wrapper have different size!" );
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  struct SurfaceFullScreenExclusiveInfoEXT
-  {
-    SurfaceFullScreenExclusiveInfoEXT( FullScreenExclusiveEXT fullScreenExclusive_ = FullScreenExclusiveEXT::eDefault )
-      : fullScreenExclusive( fullScreenExclusive_ )
-    {}
-
-    SurfaceFullScreenExclusiveInfoEXT( VkSurfaceFullScreenExclusiveInfoEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SurfaceFullScreenExclusiveInfoEXT ) );
-    }
-
-    SurfaceFullScreenExclusiveInfoEXT& operator=( VkSurfaceFullScreenExclusiveInfoEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SurfaceFullScreenExclusiveInfoEXT ) );
-      return *this;
-    }
-
-    SurfaceFullScreenExclusiveInfoEXT & setPNext( void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    SurfaceFullScreenExclusiveInfoEXT & setFullScreenExclusive( FullScreenExclusiveEXT fullScreenExclusive_ )
-    {
-      fullScreenExclusive = fullScreenExclusive_;
-      return *this;
-    }
-
-    operator VkSurfaceFullScreenExclusiveInfoEXT const&() const
-    {
-      return *reinterpret_cast<const VkSurfaceFullScreenExclusiveInfoEXT*>( this );
-    }
-
-    operator VkSurfaceFullScreenExclusiveInfoEXT &()
-    {
-      return *reinterpret_cast<VkSurfaceFullScreenExclusiveInfoEXT*>( this );
-    }
-
-    bool operator==( SurfaceFullScreenExclusiveInfoEXT const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( fullScreenExclusive == rhs.fullScreenExclusive );
-    }
-
-    bool operator!=( SurfaceFullScreenExclusiveInfoEXT const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::eSurfaceFullScreenExclusiveInfoEXT;
-
-  public:
-    void* pNext = nullptr;
-    FullScreenExclusiveEXT fullScreenExclusive;
-  };
-  static_assert( sizeof( SurfaceFullScreenExclusiveInfoEXT ) == sizeof( VkSurfaceFullScreenExclusiveInfoEXT ), "struct and wrapper have different size!" );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  struct SurfaceFullScreenExclusiveWin32InfoEXT
-  {
-    SurfaceFullScreenExclusiveWin32InfoEXT( HMONITOR hmonitor_ = 0 )
-      : hmonitor( hmonitor_ )
-    {}
-
-    SurfaceFullScreenExclusiveWin32InfoEXT( VkSurfaceFullScreenExclusiveWin32InfoEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SurfaceFullScreenExclusiveWin32InfoEXT ) );
-    }
-
-    SurfaceFullScreenExclusiveWin32InfoEXT& operator=( VkSurfaceFullScreenExclusiveWin32InfoEXT const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SurfaceFullScreenExclusiveWin32InfoEXT ) );
-      return *this;
-    }
-
-    SurfaceFullScreenExclusiveWin32InfoEXT & setPNext( const void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    SurfaceFullScreenExclusiveWin32InfoEXT & setHmonitor( HMONITOR hmonitor_ )
-    {
-      hmonitor = hmonitor_;
-      return *this;
-    }
-
-    operator VkSurfaceFullScreenExclusiveWin32InfoEXT const&() const
-    {
-      return *reinterpret_cast<const VkSurfaceFullScreenExclusiveWin32InfoEXT*>( this );
-    }
-
-    operator VkSurfaceFullScreenExclusiveWin32InfoEXT &()
-    {
-      return *reinterpret_cast<VkSurfaceFullScreenExclusiveWin32InfoEXT*>( this );
-    }
-
-    bool operator==( SurfaceFullScreenExclusiveWin32InfoEXT const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( hmonitor == rhs.hmonitor );
-    }
-
-    bool operator!=( SurfaceFullScreenExclusiveWin32InfoEXT const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::eSurfaceFullScreenExclusiveWin32InfoEXT;
-
-  public:
-    const void* pNext = nullptr;
-    HMONITOR hmonitor;
-  };
-  static_assert( sizeof( SurfaceFullScreenExclusiveWin32InfoEXT ) == sizeof( VkSurfaceFullScreenExclusiveWin32InfoEXT ), "struct and wrapper have different size!" );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
-  struct SurfaceProtectedCapabilitiesKHR
-  {
-    SurfaceProtectedCapabilitiesKHR( Bool32 supportsProtected_ = 0 )
-      : supportsProtected( supportsProtected_ )
-    {}
-
-    SurfaceProtectedCapabilitiesKHR( VkSurfaceProtectedCapabilitiesKHR const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SurfaceProtectedCapabilitiesKHR ) );
-    }
-
-    SurfaceProtectedCapabilitiesKHR& operator=( VkSurfaceProtectedCapabilitiesKHR const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SurfaceProtectedCapabilitiesKHR ) );
-      return *this;
-    }
-
-    SurfaceProtectedCapabilitiesKHR & setPNext( const void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    SurfaceProtectedCapabilitiesKHR & setSupportsProtected( Bool32 supportsProtected_ )
-    {
-      supportsProtected = supportsProtected_;
-      return *this;
-    }
-
-    operator VkSurfaceProtectedCapabilitiesKHR const&() const
-    {
-      return *reinterpret_cast<const VkSurfaceProtectedCapabilitiesKHR*>( this );
-    }
-
-    operator VkSurfaceProtectedCapabilitiesKHR &()
-    {
-      return *reinterpret_cast<VkSurfaceProtectedCapabilitiesKHR*>( this );
-    }
-
-    bool operator==( SurfaceProtectedCapabilitiesKHR const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( supportsProtected == rhs.supportsProtected );
-    }
-
-    bool operator!=( SurfaceProtectedCapabilitiesKHR const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::eSurfaceProtectedCapabilitiesKHR;
-
-  public:
-    const void* pNext = nullptr;
-    Bool32 supportsProtected;
-  };
-  static_assert( sizeof( SurfaceProtectedCapabilitiesKHR ) == sizeof( VkSurfaceProtectedCapabilitiesKHR ), "struct and wrapper have different size!" );
 
   struct SwapchainCounterCreateInfoEXT
   {
@@ -46918,66 +45989,6 @@ namespace VULKAN_HPP_NAMESPACE
     SwapchainKHR oldSwapchain;
   };
   static_assert( sizeof( SwapchainCreateInfoKHR ) == sizeof( VkSwapchainCreateInfoKHR ), "struct and wrapper have different size!" );
-
-  struct SwapchainDisplayNativeHdrCreateInfoAMD
-  {
-    SwapchainDisplayNativeHdrCreateInfoAMD( Bool32 localDimmingEnable_ = 0 )
-      : localDimmingEnable( localDimmingEnable_ )
-    {}
-
-    SwapchainDisplayNativeHdrCreateInfoAMD( VkSwapchainDisplayNativeHdrCreateInfoAMD const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SwapchainDisplayNativeHdrCreateInfoAMD ) );
-    }
-
-    SwapchainDisplayNativeHdrCreateInfoAMD& operator=( VkSwapchainDisplayNativeHdrCreateInfoAMD const & rhs )
-    {
-      memcpy( this, &rhs, sizeof( SwapchainDisplayNativeHdrCreateInfoAMD ) );
-      return *this;
-    }
-
-    SwapchainDisplayNativeHdrCreateInfoAMD & setPNext( const void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    SwapchainDisplayNativeHdrCreateInfoAMD & setLocalDimmingEnable( Bool32 localDimmingEnable_ )
-    {
-      localDimmingEnable = localDimmingEnable_;
-      return *this;
-    }
-
-    operator VkSwapchainDisplayNativeHdrCreateInfoAMD const&() const
-    {
-      return *reinterpret_cast<const VkSwapchainDisplayNativeHdrCreateInfoAMD*>( this );
-    }
-
-    operator VkSwapchainDisplayNativeHdrCreateInfoAMD &()
-    {
-      return *reinterpret_cast<VkSwapchainDisplayNativeHdrCreateInfoAMD*>( this );
-    }
-
-    bool operator==( SwapchainDisplayNativeHdrCreateInfoAMD const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( localDimmingEnable == rhs.localDimmingEnable );
-    }
-
-    bool operator!=( SwapchainDisplayNativeHdrCreateInfoAMD const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType = StructureType::eSwapchainDisplayNativeHdrCreateInfoAMD;
-
-  public:
-    const void* pNext = nullptr;
-    Bool32 localDimmingEnable;
-  };
-  static_assert( sizeof( SwapchainDisplayNativeHdrCreateInfoAMD ) == sizeof( VkSwapchainDisplayNativeHdrCreateInfoAMD ), "struct and wrapper have different size!" );
 
   struct TextureLODGatherFormatPropertiesAMD
   {
@@ -49608,23 +48619,6 @@ namespace VULKAN_HPP_NAMESPACE
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE Result Device::acquireFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d) const
-  {
-    return static_cast<Result>( d.vkAcquireFullScreenExclusiveModeEXT( m_device, static_cast<VkSwapchainKHR>( swapchain ) ) );
-  }
-#else
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE ResultValueType<void>::type Device::acquireFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d ) const
-  {
-    Result result = static_cast<Result>( d.vkAcquireFullScreenExclusiveModeEXT( m_device, static_cast<VkSwapchainKHR>( swapchain ) ) );
-    return createResultValue( result, VULKAN_HPP_NAMESPACE_STRING"::Device::acquireFullScreenExclusiveModeEXT" );
-  }
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Device::acquireNextImage2KHR( const AcquireNextImageInfoKHR* pAcquireInfo, uint32_t* pImageIndex, Dispatch const &d) const
   {
@@ -52024,23 +51018,6 @@ namespace VULKAN_HPP_NAMESPACE
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE Result Device::getGroupSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, DeviceGroupPresentModeFlagsKHR* pModes, Dispatch const &d) const
-  {
-    return static_cast<Result>( d.vkGetDeviceGroupSurfacePresentModes2EXT( m_device, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( pSurfaceInfo ), reinterpret_cast<VkDeviceGroupPresentModeFlagsKHR*>( pModes ) ) );
-  }
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE ResultValueType<DeviceGroupPresentModeFlagsKHR>::type Device::getGroupSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Dispatch const &d ) const
-  {
-    DeviceGroupPresentModeFlagsKHR modes;
-    Result result = static_cast<Result>( d.vkGetDeviceGroupSurfacePresentModes2EXT( m_device, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), reinterpret_cast<VkDeviceGroupPresentModeFlagsKHR*>( &modes ) ) );
-    return createResultValue( result, modes, VULKAN_HPP_NAMESPACE_STRING"::Device::getGroupSurfacePresentModes2EXT" );
-  }
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Device::getGroupSurfacePresentModesKHR( SurfaceKHR surface, DeviceGroupPresentModeFlagsKHR* pModes, Dispatch const &d) const
   {
@@ -53026,23 +52003,6 @@ namespace VULKAN_HPP_NAMESPACE
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE Result Device::releaseFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d) const
-  {
-    return static_cast<Result>( d.vkReleaseFullScreenExclusiveModeEXT( m_device, static_cast<VkSwapchainKHR>( swapchain ) ) );
-  }
-#else
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE ResultValueType<void>::type Device::releaseFullScreenExclusiveModeEXT( SwapchainKHR swapchain, Dispatch const &d ) const
-  {
-    Result result = static_cast<Result>( d.vkReleaseFullScreenExclusiveModeEXT( m_device, static_cast<VkSwapchainKHR>( swapchain ) ) );
-    return createResultValue( result, VULKAN_HPP_NAMESPACE_STRING"::Device::releaseFullScreenExclusiveModeEXT" );
-  }
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
 #ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Device::resetCommandPool( CommandPool commandPool, CommandPoolResetFlags flags, Dispatch const &d) const
@@ -53099,20 +52059,6 @@ namespace VULKAN_HPP_NAMESPACE
   {
     Result result = static_cast<Result>( d.vkResetFences( m_device, fences.size() , reinterpret_cast<const VkFence*>( fences.data() ) ) );
     return createResultValue( result, VULKAN_HPP_NAMESPACE_STRING"::Device::resetFences" );
-  }
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
-#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE void Device::resetQueryPoolEXT( QueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, Dispatch const &d) const
-  {
-    d.vkResetQueryPoolEXT( m_device, static_cast<VkQueryPool>( queryPool ), firstQuery, queryCount );
-  }
-#else
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE void Device::resetQueryPoolEXT( QueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, Dispatch const &d ) const
-  {
-    d.vkResetQueryPoolEXT( m_device, static_cast<VkQueryPool>( queryPool ), firstQuery, queryCount );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -53177,20 +52123,6 @@ namespace VULKAN_HPP_NAMESPACE
     }
 #endif  /*VULKAN_HPP_NO_EXCEPTIONS*/
     d.vkSetHdrMetadataEXT( m_device, swapchains.size() , reinterpret_cast<const VkSwapchainKHR*>( swapchains.data() ), reinterpret_cast<const VkHdrMetadataEXT*>( metadata.data() ) );
-  }
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
-#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE void Device::setLocalDimmingAMD( SwapchainKHR swapChain, Bool32 localDimmingEnable, Dispatch const &d) const
-  {
-    d.vkSetLocalDimmingAMD( m_device, static_cast<VkSwapchainKHR>( swapChain ), static_cast<VkBool32>( localDimmingEnable ) );
-  }
-#else
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE void Device::setLocalDimmingAMD( SwapchainKHR swapChain, Bool32 localDimmingEnable, Dispatch const &d ) const
-  {
-    d.vkSetLocalDimmingAMD( m_device, static_cast<VkSwapchainKHR>( swapChain ), static_cast<VkBool32>( localDimmingEnable ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -53419,32 +52351,6 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE Result Instance::createHeadlessSurfaceEXT( const HeadlessSurfaceCreateInfoEXT* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d) const
-  {
-    return static_cast<Result>( d.vkCreateHeadlessSurfaceEXT( m_instance, reinterpret_cast<const VkHeadlessSurfaceCreateInfoEXT*>( pCreateInfo ), reinterpret_cast<const VkAllocationCallbacks*>( pAllocator ), reinterpret_cast<VkSurfaceKHR*>( pSurface ) ) );
-  }
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createHeadlessSurfaceEXT( const HeadlessSurfaceCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
-  {
-    SurfaceKHR surface;
-    Result result = static_cast<Result>( d.vkCreateHeadlessSurfaceEXT( m_instance, reinterpret_cast<const VkHeadlessSurfaceCreateInfoEXT*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
-    return createResultValue( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createHeadlessSurfaceEXT" );
-  }
-#ifndef VULKAN_HPP_NO_SMART_HANDLE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type Instance::createHeadlessSurfaceEXTUnique( const HeadlessSurfaceCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
-  {
-    SurfaceKHR surface;
-    Result result = static_cast<Result>( d.vkCreateHeadlessSurfaceEXT( m_instance, reinterpret_cast<const VkHeadlessSurfaceCreateInfoEXT*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
-
-    ObjectDestroy<Instance,Dispatch> deleter( *this, allocator, d );
-    return createResultValue<SurfaceKHR,Dispatch>( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createHeadlessSurfaceEXTUnique", deleter );
-  }
-#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
 #ifdef VK_USE_PLATFORM_IOS_MVK
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result Instance::createIOSSurfaceMVK( const IOSSurfaceCreateInfoMVK* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d) const
@@ -53556,34 +52462,6 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
-
-#ifdef VK_USE_PLATFORM_GGP
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE Result Instance::createStreamDescriptorSurfaceGGP( const StreamDescriptorSurfaceCreateInfoGGP* pCreateInfo, const AllocationCallbacks* pAllocator, SurfaceKHR* pSurface, Dispatch const &d) const
-  {
-    return static_cast<Result>( d.vkCreateStreamDescriptorSurfaceGGP( m_instance, reinterpret_cast<const VkStreamDescriptorSurfaceCreateInfoGGP*>( pCreateInfo ), reinterpret_cast<const VkAllocationCallbacks*>( pAllocator ), reinterpret_cast<VkSurfaceKHR*>( pSurface ) ) );
-  }
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createStreamDescriptorSurfaceGGP( const StreamDescriptorSurfaceCreateInfoGGP & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
-  {
-    SurfaceKHR surface;
-    Result result = static_cast<Result>( d.vkCreateStreamDescriptorSurfaceGGP( m_instance, reinterpret_cast<const VkStreamDescriptorSurfaceCreateInfoGGP*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
-    return createResultValue( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createStreamDescriptorSurfaceGGP" );
-  }
-#ifndef VULKAN_HPP_NO_SMART_HANDLE
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE typename ResultValueType<UniqueHandle<SurfaceKHR,Dispatch>>::type Instance::createStreamDescriptorSurfaceGGPUnique( const StreamDescriptorSurfaceCreateInfoGGP & createInfo, Optional<const AllocationCallbacks> allocator, Dispatch const &d ) const
-  {
-    SurfaceKHR surface;
-    Result result = static_cast<Result>( d.vkCreateStreamDescriptorSurfaceGGP( m_instance, reinterpret_cast<const VkStreamDescriptorSurfaceCreateInfoGGP*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
-
-    ObjectDestroy<Instance,Dispatch> deleter( *this, allocator, d );
-    return createResultValue<SurfaceKHR,Dispatch>( result, surface, VULKAN_HPP_NAMESPACE_STRING"::Instance::createStreamDescriptorSurfaceGGPUnique", deleter );
-  }
-#endif /*VULKAN_HPP_NO_SMART_HANDLE*/
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_GGP*/
 
 #ifdef VK_USE_PLATFORM_VI_NN
   template<typename Dispatch>
@@ -55536,60 +54414,6 @@ namespace VULKAN_HPP_NAMESPACE
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  template<typename Dispatch>
-  VULKAN_HPP_INLINE Result PhysicalDevice::getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, uint32_t* pPresentModeCount, PresentModeKHR* pPresentModes, Dispatch const &d) const
-  {
-    return static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( pSurfaceInfo ), pPresentModeCount, reinterpret_cast<VkPresentModeKHR*>( pPresentModes ) ) );
-  }
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  template<typename Allocator, typename Dispatch>
-  VULKAN_HPP_INLINE typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type PhysicalDevice::getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Dispatch const &d ) const
-  {
-    std::vector<PresentModeKHR,Allocator> presentModes;
-    uint32_t presentModeCount;
-    Result result;
-    do
-    {
-      result = static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), &presentModeCount, nullptr ) );
-      if ( ( result == Result::eSuccess ) && presentModeCount )
-      {
-        presentModes.resize( presentModeCount );
-        result = static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), &presentModeCount, reinterpret_cast<VkPresentModeKHR*>( presentModes.data() ) ) );
-      }
-    } while ( result == Result::eIncomplete );
-    if ( result == Result::eSuccess )
-    {
-      VULKAN_HPP_ASSERT( presentModeCount <= presentModes.size() );
-      presentModes.resize( presentModeCount );
-    }
-    return createResultValue( result, presentModes, VULKAN_HPP_NAMESPACE_STRING"::PhysicalDevice::getSurfacePresentModes2EXT" );
-  }
-  template<typename Allocator, typename Dispatch>
-  VULKAN_HPP_INLINE typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type PhysicalDevice::getSurfacePresentModes2EXT( const PhysicalDeviceSurfaceInfo2KHR & surfaceInfo, Allocator const& vectorAllocator, Dispatch const &d ) const
-  {
-    std::vector<PresentModeKHR,Allocator> presentModes( vectorAllocator );
-    uint32_t presentModeCount;
-    Result result;
-    do
-    {
-      result = static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), &presentModeCount, nullptr ) );
-      if ( ( result == Result::eSuccess ) && presentModeCount )
-      {
-        presentModes.resize( presentModeCount );
-        result = static_cast<Result>( d.vkGetPhysicalDeviceSurfacePresentModes2EXT( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceSurfaceInfo2KHR*>( &surfaceInfo ), &presentModeCount, reinterpret_cast<VkPresentModeKHR*>( presentModes.data() ) ) );
-      }
-    } while ( result == Result::eIncomplete );
-    if ( result == Result::eSuccess )
-    {
-      VULKAN_HPP_ASSERT( presentModeCount <= presentModes.size() );
-      presentModes.resize( presentModeCount );
-    }
-    return createResultValue( result, presentModes, VULKAN_HPP_NAMESPACE_STRING"::PhysicalDevice::getSurfacePresentModes2EXT" );
-  }
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-
   template<typename Dispatch>
   VULKAN_HPP_INLINE Result PhysicalDevice::getSurfacePresentModesKHR( SurfaceKHR surface, uint32_t* pPresentModeCount, PresentModeKHR* pPresentModes, Dispatch const &d) const
   {
@@ -55908,7 +54732,6 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<SwapchainCreateInfoKHR, DeviceGroupSwapchainCreateInfoKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, DeviceMemoryOverallocationCreateInfoAMD>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceQueueCreateInfo, DeviceQueueGlobalPriorityCreateInfoEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<SurfaceCapabilities2KHR, DisplayNativeHdrSurfaceCapabilitiesAMD>{ enum { value = true }; };
   template <> struct isStructureChainValid<PresentInfoKHR, DisplayPresentInfoKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<FormatProperties2, DrmFormatModifierPropertiesListEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<FenceCreateInfo, ExportFenceCreateInfo>{ enum { value = true }; };
@@ -55971,8 +54794,8 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceBlendOperationAdvancedFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceBlendOperationAdvancedFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceBlendOperationAdvancedPropertiesEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceBufferDeviceAddressFeaturesEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceBufferDeviceAddressFeaturesEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceBufferAddressFeaturesEXT>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceBufferAddressFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceComputeShaderDerivativesFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceComputeShaderDerivativesFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceConditionalRenderingFeaturesEXT>{ enum { value = true }; };
@@ -56006,8 +54829,6 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceFragmentDensityMapPropertiesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceFragmentShaderBarycentricFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceFragmentShaderBarycentricFeaturesNV>{ enum { value = true }; };
-  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceHostQueryResetFeaturesEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceHostQueryResetFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceIDProperties>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceImageFormatInfo2, PhysicalDeviceImageDrmFormatModifierInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceImageFormatInfo2, PhysicalDeviceImageViewImageFormatInfoEXT>{ enum { value = true }; };
@@ -56043,8 +54864,8 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderAtomicInt64FeaturesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderAtomicInt64FeaturesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceShaderCorePropertiesAMD>{ enum { value = true }; };
-  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderDrawParametersFeatures>{ enum { value = true }; };
-  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderDrawParametersFeatures>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderDrawParameterFeatures>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderDrawParameterFeatures>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShaderImageFootprintFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceShaderImageFootprintFeaturesNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceShadingRateImageFeaturesNV>{ enum { value = true }; };
@@ -56054,8 +54875,8 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceTransformFeedbackFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceTransformFeedbackFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceTransformFeedbackPropertiesEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVariablePointersFeatures>{ enum { value = true }; };
-  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVariablePointersFeatures>{ enum { value = true }; };
+  template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVariablePointerFeatures>{ enum { value = true }; };
+  template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVariablePointerFeatures>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceFeatures2, PhysicalDeviceVertexAttributeDivisorFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<DeviceCreateInfo, PhysicalDeviceVertexAttributeDivisorFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PhysicalDeviceProperties2, PhysicalDeviceVertexAttributeDivisorPropertiesEXT>{ enum { value = true }; };
@@ -56066,9 +54887,6 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PipelineColorBlendStateCreateInfo, PipelineColorBlendAdvancedStateCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineMultisampleStateCreateInfo, PipelineCoverageModulationStateCreateInfoNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineMultisampleStateCreateInfo, PipelineCoverageToColorStateCreateInfoNV>{ enum { value = true }; };
-  template <> struct isStructureChainValid<GraphicsPipelineCreateInfo, PipelineCreationFeedbackCreateInfoEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<ComputePipelineCreateInfo, PipelineCreationFeedbackCreateInfoEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<RayTracingPipelineCreateInfoNV, PipelineCreationFeedbackCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<GraphicsPipelineCreateInfo, PipelineDiscardRectangleStateCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineRasterizationStateCreateInfo, PipelineRasterizationConservativeStateCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineRasterizationStateCreateInfo, PipelineRasterizationDepthClipStateCreateInfoEXT>{ enum { value = true }; };
@@ -56083,9 +54901,6 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<PipelineViewportStateCreateInfo, PipelineViewportShadingRateImageStateCreateInfoNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineViewportStateCreateInfo, PipelineViewportSwizzleStateCreateInfoNV>{ enum { value = true }; };
   template <> struct isStructureChainValid<PipelineViewportStateCreateInfo, PipelineViewportWScalingStateCreateInfoNV>{ enum { value = true }; };
-#ifdef VK_USE_PLATFORM_GGP
-  template <> struct isStructureChainValid<PresentInfoKHR, PresentFrameTokenGGP>{ enum { value = true }; };
-#endif /*VK_USE_PLATFORM_GGP*/
   template <> struct isStructureChainValid<PresentInfoKHR, PresentRegionsKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<PresentInfoKHR, PresentTimesInfoGOOGLE>{ enum { value = true }; };
   template <> struct isStructureChainValid<SubmitInfo, ProtectedSubmitInfo>{ enum { value = true }; };
@@ -56102,20 +54917,7 @@ namespace VULKAN_HPP_NAMESPACE
   template <> struct isStructureChainValid<ShaderModuleCreateInfo, ShaderModuleValidationCacheCreateInfoEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<SurfaceCapabilities2KHR, SharedPresentSurfaceCapabilitiesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<SubpassDescription2KHR, SubpassDescriptionDepthStencilResolveKHR>{ enum { value = true }; };
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  template <> struct isStructureChainValid<SurfaceCapabilities2KHR, SurfaceCapabilitiesFullScreenExclusiveEXT>{ enum { value = true }; };
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  template <> struct isStructureChainValid<PhysicalDeviceSurfaceInfo2KHR, SurfaceFullScreenExclusiveInfoEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<SwapchainCreateInfoKHR, SurfaceFullScreenExclusiveInfoEXT>{ enum { value = true }; };
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-  template <> struct isStructureChainValid<PhysicalDeviceSurfaceInfo2KHR, SurfaceFullScreenExclusiveWin32InfoEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<SwapchainCreateInfoKHR, SurfaceFullScreenExclusiveWin32InfoEXT>{ enum { value = true }; };
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
-  template <> struct isStructureChainValid<SurfaceCapabilities2KHR, SurfaceProtectedCapabilitiesKHR>{ enum { value = true }; };
   template <> struct isStructureChainValid<SwapchainCreateInfoKHR, SwapchainCounterCreateInfoEXT>{ enum { value = true }; };
-  template <> struct isStructureChainValid<SwapchainCreateInfoKHR, SwapchainDisplayNativeHdrCreateInfoAMD>{ enum { value = true }; };
   template <> struct isStructureChainValid<ImageFormatProperties2, TextureLODGatherFormatPropertiesAMD>{ enum { value = true }; };
   template <> struct isStructureChainValid<InstanceCreateInfo, ValidationFeaturesEXT>{ enum { value = true }; };
   template <> struct isStructureChainValid<InstanceCreateInfo, ValidationFlagsEXT>{ enum { value = true }; };
@@ -56227,9 +55029,6 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkCmdWriteTimestamp vkCmdWriteTimestamp = 0;
     PFN_vkEndCommandBuffer vkEndCommandBuffer = 0;
     PFN_vkResetCommandBuffer vkResetCommandBuffer = 0;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    PFN_vkAcquireFullScreenExclusiveModeEXT vkAcquireFullScreenExclusiveModeEXT = 0;
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
     PFN_vkAcquireNextImage2KHR vkAcquireNextImage2KHR = 0;
     PFN_vkAcquireNextImageKHR vkAcquireNextImageKHR = 0;
     PFN_vkAllocateCommandBuffers vkAllocateCommandBuffers = 0;
@@ -56325,9 +55124,6 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkGetDeviceGroupPeerMemoryFeatures vkGetDeviceGroupPeerMemoryFeatures = 0;
     PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR vkGetDeviceGroupPeerMemoryFeaturesKHR = 0;
     PFN_vkGetDeviceGroupPresentCapabilitiesKHR vkGetDeviceGroupPresentCapabilitiesKHR = 0;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    PFN_vkGetDeviceGroupSurfacePresentModes2EXT vkGetDeviceGroupSurfacePresentModes2EXT = 0;
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
     PFN_vkGetDeviceGroupSurfacePresentModesKHR vkGetDeviceGroupSurfacePresentModesKHR = 0;
     PFN_vkGetDeviceMemoryCommitment vkGetDeviceMemoryCommitment = 0;
     PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr = 0;
@@ -56393,19 +55189,14 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkRegisterDeviceEventEXT vkRegisterDeviceEventEXT = 0;
     PFN_vkRegisterDisplayEventEXT vkRegisterDisplayEventEXT = 0;
     PFN_vkRegisterObjectsNVX vkRegisterObjectsNVX = 0;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    PFN_vkReleaseFullScreenExclusiveModeEXT vkReleaseFullScreenExclusiveModeEXT = 0;
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
     PFN_vkResetCommandPool vkResetCommandPool = 0;
     PFN_vkResetDescriptorPool vkResetDescriptorPool = 0;
     PFN_vkResetEvent vkResetEvent = 0;
     PFN_vkResetFences vkResetFences = 0;
-    PFN_vkResetQueryPoolEXT vkResetQueryPoolEXT = 0;
     PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = 0;
     PFN_vkSetDebugUtilsObjectTagEXT vkSetDebugUtilsObjectTagEXT = 0;
     PFN_vkSetEvent vkSetEvent = 0;
     PFN_vkSetHdrMetadataEXT vkSetHdrMetadataEXT = 0;
-    PFN_vkSetLocalDimmingAMD vkSetLocalDimmingAMD = 0;
     PFN_vkTrimCommandPool vkTrimCommandPool = 0;
     PFN_vkTrimCommandPoolKHR vkTrimCommandPoolKHR = 0;
     PFN_vkUnmapMemory vkUnmapMemory = 0;
@@ -56420,7 +55211,6 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkCreateDebugReportCallbackEXT vkCreateDebugReportCallbackEXT = 0;
     PFN_vkCreateDebugUtilsMessengerEXT vkCreateDebugUtilsMessengerEXT = 0;
     PFN_vkCreateDisplayPlaneSurfaceKHR vkCreateDisplayPlaneSurfaceKHR = 0;
-    PFN_vkCreateHeadlessSurfaceEXT vkCreateHeadlessSurfaceEXT = 0;
 #ifdef VK_USE_PLATFORM_IOS_MVK
     PFN_vkCreateIOSSurfaceMVK vkCreateIOSSurfaceMVK = 0;
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
@@ -56433,9 +55223,6 @@ namespace VULKAN_HPP_NAMESPACE
 #ifdef VK_USE_PLATFORM_METAL_EXT
     PFN_vkCreateMetalSurfaceEXT vkCreateMetalSurfaceEXT = 0;
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
-#ifdef VK_USE_PLATFORM_GGP
-    PFN_vkCreateStreamDescriptorSurfaceGGP vkCreateStreamDescriptorSurfaceGGP = 0;
-#endif /*VK_USE_PLATFORM_GGP*/
 #ifdef VK_USE_PLATFORM_VI_NN
     PFN_vkCreateViSurfaceNN vkCreateViSurfaceNN = 0;
 #endif /*VK_USE_PLATFORM_VI_NN*/
@@ -56515,9 +55302,6 @@ namespace VULKAN_HPP_NAMESPACE
     PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR vkGetPhysicalDeviceSurfaceCapabilitiesKHR = 0;
     PFN_vkGetPhysicalDeviceSurfaceFormats2KHR vkGetPhysicalDeviceSurfaceFormats2KHR = 0;
     PFN_vkGetPhysicalDeviceSurfaceFormatsKHR vkGetPhysicalDeviceSurfaceFormatsKHR = 0;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT vkGetPhysicalDeviceSurfacePresentModes2EXT = 0;
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
     PFN_vkGetPhysicalDeviceSurfacePresentModesKHR vkGetPhysicalDeviceSurfacePresentModesKHR = 0;
     PFN_vkGetPhysicalDeviceSurfaceSupportKHR vkGetPhysicalDeviceSurfaceSupportKHR = 0;
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
@@ -56669,9 +55453,6 @@ namespace VULKAN_HPP_NAMESPACE
       vkCmdWriteTimestamp = PFN_vkCmdWriteTimestamp( device ? vkGetDeviceProcAddr( device, "vkCmdWriteTimestamp" ) : vkGetInstanceProcAddr( instance, "vkCmdWriteTimestamp" ) );
       vkEndCommandBuffer = PFN_vkEndCommandBuffer( device ? vkGetDeviceProcAddr( device, "vkEndCommandBuffer" ) : vkGetInstanceProcAddr( instance, "vkEndCommandBuffer" ) );
       vkResetCommandBuffer = PFN_vkResetCommandBuffer( device ? vkGetDeviceProcAddr( device, "vkResetCommandBuffer" ) : vkGetInstanceProcAddr( instance, "vkResetCommandBuffer" ) );
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-      vkAcquireFullScreenExclusiveModeEXT = PFN_vkAcquireFullScreenExclusiveModeEXT( device ? vkGetDeviceProcAddr( device, "vkAcquireFullScreenExclusiveModeEXT" ) : vkGetInstanceProcAddr( instance, "vkAcquireFullScreenExclusiveModeEXT" ) );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkAcquireNextImage2KHR = PFN_vkAcquireNextImage2KHR( device ? vkGetDeviceProcAddr( device, "vkAcquireNextImage2KHR" ) : vkGetInstanceProcAddr( instance, "vkAcquireNextImage2KHR" ) );
       vkAcquireNextImageKHR = PFN_vkAcquireNextImageKHR( device ? vkGetDeviceProcAddr( device, "vkAcquireNextImageKHR" ) : vkGetInstanceProcAddr( instance, "vkAcquireNextImageKHR" ) );
       vkAllocateCommandBuffers = PFN_vkAllocateCommandBuffers( device ? vkGetDeviceProcAddr( device, "vkAllocateCommandBuffers" ) : vkGetInstanceProcAddr( instance, "vkAllocateCommandBuffers" ) );
@@ -56767,9 +55548,6 @@ namespace VULKAN_HPP_NAMESPACE
       vkGetDeviceGroupPeerMemoryFeatures = PFN_vkGetDeviceGroupPeerMemoryFeatures( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupPeerMemoryFeatures" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupPeerMemoryFeatures" ) );
       vkGetDeviceGroupPeerMemoryFeaturesKHR = PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupPeerMemoryFeaturesKHR" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupPeerMemoryFeaturesKHR" ) );
       vkGetDeviceGroupPresentCapabilitiesKHR = PFN_vkGetDeviceGroupPresentCapabilitiesKHR( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupPresentCapabilitiesKHR" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupPresentCapabilitiesKHR" ) );
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-      vkGetDeviceGroupSurfacePresentModes2EXT = PFN_vkGetDeviceGroupSurfacePresentModes2EXT( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupSurfacePresentModes2EXT" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupSurfacePresentModes2EXT" ) );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkGetDeviceGroupSurfacePresentModesKHR = PFN_vkGetDeviceGroupSurfacePresentModesKHR( device ? vkGetDeviceProcAddr( device, "vkGetDeviceGroupSurfacePresentModesKHR" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceGroupSurfacePresentModesKHR" ) );
       vkGetDeviceMemoryCommitment = PFN_vkGetDeviceMemoryCommitment( device ? vkGetDeviceProcAddr( device, "vkGetDeviceMemoryCommitment" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceMemoryCommitment" ) );
       vkGetDeviceQueue = PFN_vkGetDeviceQueue( device ? vkGetDeviceProcAddr( device, "vkGetDeviceQueue" ) : vkGetInstanceProcAddr( instance, "vkGetDeviceQueue" ) );
@@ -56834,19 +55612,14 @@ namespace VULKAN_HPP_NAMESPACE
       vkRegisterDeviceEventEXT = PFN_vkRegisterDeviceEventEXT( device ? vkGetDeviceProcAddr( device, "vkRegisterDeviceEventEXT" ) : vkGetInstanceProcAddr( instance, "vkRegisterDeviceEventEXT" ) );
       vkRegisterDisplayEventEXT = PFN_vkRegisterDisplayEventEXT( device ? vkGetDeviceProcAddr( device, "vkRegisterDisplayEventEXT" ) : vkGetInstanceProcAddr( instance, "vkRegisterDisplayEventEXT" ) );
       vkRegisterObjectsNVX = PFN_vkRegisterObjectsNVX( device ? vkGetDeviceProcAddr( device, "vkRegisterObjectsNVX" ) : vkGetInstanceProcAddr( instance, "vkRegisterObjectsNVX" ) );
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-      vkReleaseFullScreenExclusiveModeEXT = PFN_vkReleaseFullScreenExclusiveModeEXT( device ? vkGetDeviceProcAddr( device, "vkReleaseFullScreenExclusiveModeEXT" ) : vkGetInstanceProcAddr( instance, "vkReleaseFullScreenExclusiveModeEXT" ) );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkResetCommandPool = PFN_vkResetCommandPool( device ? vkGetDeviceProcAddr( device, "vkResetCommandPool" ) : vkGetInstanceProcAddr( instance, "vkResetCommandPool" ) );
       vkResetDescriptorPool = PFN_vkResetDescriptorPool( device ? vkGetDeviceProcAddr( device, "vkResetDescriptorPool" ) : vkGetInstanceProcAddr( instance, "vkResetDescriptorPool" ) );
       vkResetEvent = PFN_vkResetEvent( device ? vkGetDeviceProcAddr( device, "vkResetEvent" ) : vkGetInstanceProcAddr( instance, "vkResetEvent" ) );
       vkResetFences = PFN_vkResetFences( device ? vkGetDeviceProcAddr( device, "vkResetFences" ) : vkGetInstanceProcAddr( instance, "vkResetFences" ) );
-      vkResetQueryPoolEXT = PFN_vkResetQueryPoolEXT( device ? vkGetDeviceProcAddr( device, "vkResetQueryPoolEXT" ) : vkGetInstanceProcAddr( instance, "vkResetQueryPoolEXT" ) );
       vkSetDebugUtilsObjectNameEXT = PFN_vkSetDebugUtilsObjectNameEXT( device ? vkGetDeviceProcAddr( device, "vkSetDebugUtilsObjectNameEXT" ) : vkGetInstanceProcAddr( instance, "vkSetDebugUtilsObjectNameEXT" ) );
       vkSetDebugUtilsObjectTagEXT = PFN_vkSetDebugUtilsObjectTagEXT( device ? vkGetDeviceProcAddr( device, "vkSetDebugUtilsObjectTagEXT" ) : vkGetInstanceProcAddr( instance, "vkSetDebugUtilsObjectTagEXT" ) );
       vkSetEvent = PFN_vkSetEvent( device ? vkGetDeviceProcAddr( device, "vkSetEvent" ) : vkGetInstanceProcAddr( instance, "vkSetEvent" ) );
       vkSetHdrMetadataEXT = PFN_vkSetHdrMetadataEXT( device ? vkGetDeviceProcAddr( device, "vkSetHdrMetadataEXT" ) : vkGetInstanceProcAddr( instance, "vkSetHdrMetadataEXT" ) );
-      vkSetLocalDimmingAMD = PFN_vkSetLocalDimmingAMD( device ? vkGetDeviceProcAddr( device, "vkSetLocalDimmingAMD" ) : vkGetInstanceProcAddr( instance, "vkSetLocalDimmingAMD" ) );
       vkTrimCommandPool = PFN_vkTrimCommandPool( device ? vkGetDeviceProcAddr( device, "vkTrimCommandPool" ) : vkGetInstanceProcAddr( instance, "vkTrimCommandPool" ) );
       vkTrimCommandPoolKHR = PFN_vkTrimCommandPoolKHR( device ? vkGetDeviceProcAddr( device, "vkTrimCommandPoolKHR" ) : vkGetInstanceProcAddr( instance, "vkTrimCommandPoolKHR" ) );
       vkUnmapMemory = PFN_vkUnmapMemory( device ? vkGetDeviceProcAddr( device, "vkUnmapMemory" ) : vkGetInstanceProcAddr( instance, "vkUnmapMemory" ) );
@@ -56861,7 +55634,6 @@ namespace VULKAN_HPP_NAMESPACE
       vkCreateDebugReportCallbackEXT = PFN_vkCreateDebugReportCallbackEXT( vkGetInstanceProcAddr( instance, "vkCreateDebugReportCallbackEXT" ) );
       vkCreateDebugUtilsMessengerEXT = PFN_vkCreateDebugUtilsMessengerEXT( vkGetInstanceProcAddr( instance, "vkCreateDebugUtilsMessengerEXT" ) );
       vkCreateDisplayPlaneSurfaceKHR = PFN_vkCreateDisplayPlaneSurfaceKHR( vkGetInstanceProcAddr( instance, "vkCreateDisplayPlaneSurfaceKHR" ) );
-      vkCreateHeadlessSurfaceEXT = PFN_vkCreateHeadlessSurfaceEXT( vkGetInstanceProcAddr( instance, "vkCreateHeadlessSurfaceEXT" ) );
 #ifdef VK_USE_PLATFORM_IOS_MVK
       vkCreateIOSSurfaceMVK = PFN_vkCreateIOSSurfaceMVK( vkGetInstanceProcAddr( instance, "vkCreateIOSSurfaceMVK" ) );
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
@@ -56874,9 +55646,6 @@ namespace VULKAN_HPP_NAMESPACE
 #ifdef VK_USE_PLATFORM_METAL_EXT
       vkCreateMetalSurfaceEXT = PFN_vkCreateMetalSurfaceEXT( vkGetInstanceProcAddr( instance, "vkCreateMetalSurfaceEXT" ) );
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
-#ifdef VK_USE_PLATFORM_GGP
-      vkCreateStreamDescriptorSurfaceGGP = PFN_vkCreateStreamDescriptorSurfaceGGP( vkGetInstanceProcAddr( instance, "vkCreateStreamDescriptorSurfaceGGP" ) );
-#endif /*VK_USE_PLATFORM_GGP*/
 #ifdef VK_USE_PLATFORM_VI_NN
       vkCreateViSurfaceNN = PFN_vkCreateViSurfaceNN( vkGetInstanceProcAddr( instance, "vkCreateViSurfaceNN" ) );
 #endif /*VK_USE_PLATFORM_VI_NN*/
@@ -56955,9 +55724,6 @@ namespace VULKAN_HPP_NAMESPACE
       vkGetPhysicalDeviceSurfaceCapabilitiesKHR = PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" ) );
       vkGetPhysicalDeviceSurfaceFormats2KHR = PFN_vkGetPhysicalDeviceSurfaceFormats2KHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceFormats2KHR" ) );
       vkGetPhysicalDeviceSurfaceFormatsKHR = PFN_vkGetPhysicalDeviceSurfaceFormatsKHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceFormatsKHR" ) );
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-      vkGetPhysicalDeviceSurfacePresentModes2EXT = PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfacePresentModes2EXT" ) );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
       vkGetPhysicalDeviceSurfacePresentModesKHR = PFN_vkGetPhysicalDeviceSurfacePresentModesKHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfacePresentModesKHR" ) );
       vkGetPhysicalDeviceSurfaceSupportKHR = PFN_vkGetPhysicalDeviceSurfaceSupportKHR( vkGetInstanceProcAddr( instance, "vkGetPhysicalDeviceSurfaceSupportKHR" ) );
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR

--- a/include/vulkan/vulkan_core.h
+++ b/include/vulkan/vulkan_core.h
@@ -43,7 +43,7 @@ extern "C" {
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
 #define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
 // Version of this file
-#define VK_HEADER_VERSION 107
+#define VK_HEADER_VERSION 108
 
 
 #define VK_NULL_HANDLE 0
@@ -484,7 +484,11 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV = 1000249000,
     VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV = 1000249001,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV = 1000249002,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV = 1000250000,
+    VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV = 1000250001,
+    VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV = 1000250002,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT = 1000252000,
+    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR = 1000253000,
     VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT = 1000255000,
     VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT = 1000255002,
     VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT = 1000255001,
@@ -4729,7 +4733,7 @@ typedef enum VkColorSpaceKHR {
     VK_COLOR_SPACE_SRGB_NONLINEAR_KHR = 0,
     VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT = 1000104001,
     VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT = 1000104002,
-    VK_COLOR_SPACE_DCI_P3_LINEAR_EXT = 1000104003,
+    VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT = 1000104003,
     VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT = 1000104004,
     VK_COLOR_SPACE_BT709_LINEAR_EXT = 1000104005,
     VK_COLOR_SPACE_BT709_NONLINEAR_EXT = 1000104006,
@@ -4743,6 +4747,7 @@ typedef enum VkColorSpaceKHR {
     VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT = 1000104014,
     VK_COLOR_SPACE_DISPLAY_NATIVE_AMD = 1000213000,
     VK_COLORSPACE_SRGB_NONLINEAR_KHR = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
+    VK_COLOR_SPACE_DCI_P3_LINEAR_EXT = VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT,
     VK_COLOR_SPACE_BEGIN_RANGE_KHR = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
     VK_COLOR_SPACE_END_RANGE_KHR = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,
     VK_COLOR_SPACE_RANGE_SIZE_KHR = (VK_COLOR_SPACE_SRGB_NONLINEAR_KHR - VK_COLOR_SPACE_SRGB_NONLINEAR_KHR + 1),
@@ -5252,16 +5257,9 @@ typedef VkBindBufferMemoryDeviceGroupInfo VkBindBufferMemoryDeviceGroupInfoKHR;
 
 typedef VkBindImageMemoryDeviceGroupInfo VkBindImageMemoryDeviceGroupInfoKHR;
 
-typedef struct VkPhysicalDeviceSurfaceInfo2KHR {
-    VkStructureType    sType;
-    const void*        pNext;
-    VkSurfaceKHR       surface;
-} VkPhysicalDeviceSurfaceInfo2KHR;
-
 typedef void (VKAPI_PTR *PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR)(VkDevice device, uint32_t heapIndex, uint32_t localDeviceIndex, uint32_t remoteDeviceIndex, VkPeerMemoryFeatureFlags* pPeerMemoryFeatures);
 typedef void (VKAPI_PTR *PFN_vkCmdSetDeviceMaskKHR)(VkCommandBuffer commandBuffer, uint32_t deviceMask);
 typedef void (VKAPI_PTR *PFN_vkCmdDispatchBaseKHR)(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY, uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ);
-typedef VkResult (VKAPI_PTR *PFN_vkGetDeviceGroupSurfacePresentModes2EXT)(VkDevice device, const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo, VkDeviceGroupPresentModeFlagsKHR* pModes);
 
 #ifndef VK_NO_PROTOTYPES
 VKAPI_ATTR void VKAPI_CALL vkGetDeviceGroupPeerMemoryFeaturesKHR(
@@ -5283,11 +5281,6 @@ VKAPI_ATTR void VKAPI_CALL vkCmdDispatchBaseKHR(
     uint32_t                                    groupCountX,
     uint32_t                                    groupCountY,
     uint32_t                                    groupCountZ);
-
-VKAPI_ATTR VkResult VKAPI_CALL vkGetDeviceGroupSurfacePresentModes2EXT(
-    VkDevice                                    device,
-    const VkPhysicalDeviceSurfaceInfo2KHR*      pSurfaceInfo,
-    VkDeviceGroupPresentModeFlagsKHR*           pModes);
 #endif
 
 
@@ -5811,6 +5804,12 @@ typedef VkPipelineTessellationDomainOriginStateCreateInfo VkPipelineTessellation
 #define VK_KHR_get_surface_capabilities2 1
 #define VK_KHR_GET_SURFACE_CAPABILITIES_2_SPEC_VERSION 1
 #define VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME "VK_KHR_get_surface_capabilities2"
+typedef struct VkPhysicalDeviceSurfaceInfo2KHR {
+    VkStructureType    sType;
+    const void*        pNext;
+    VkSurfaceKHR       surface;
+} VkPhysicalDeviceSurfaceInfo2KHR;
+
 typedef struct VkSurfaceCapabilities2KHR {
     VkStructureType             sType;
     void*                       pNext;
@@ -6235,6 +6234,17 @@ typedef struct VkSurfaceProtectedCapabilitiesKHR {
     const void*        pNext;
     VkBool32           supportsProtected;
 } VkSurfaceProtectedCapabilitiesKHR;
+
+
+
+#define VK_KHR_uniform_buffer_standard_layout 1
+#define VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_SPEC_VERSION 1
+#define VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME "VK_KHR_uniform_buffer_standard_layout"
+typedef struct VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           uniformBufferStandardLayout;
+} VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR;
 
 
 
@@ -7436,7 +7446,7 @@ typedef struct VkPipelineRasterizationDepthClipStateCreateInfoEXT {
 
 
 #define VK_EXT_swapchain_colorspace 1
-#define VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION 3
+#define VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION 4
 #define VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME "VK_EXT_swapchain_colorspace"
 
 
@@ -9161,6 +9171,51 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
     VkPhysicalDevice                            physicalDevice,
     uint32_t*                                   pPropertyCount,
     VkCooperativeMatrixPropertiesNV*            pProperties);
+#endif
+
+
+#define VK_NV_coverage_reduction_mode 1
+#define VK_NV_COVERAGE_REDUCTION_MODE_SPEC_VERSION 1
+#define VK_NV_COVERAGE_REDUCTION_MODE_EXTENSION_NAME "VK_NV_coverage_reduction_mode"
+
+typedef enum VkCoverageReductionModeNV {
+    VK_COVERAGE_REDUCTION_MODE_MERGE_NV = 0,
+    VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV = 1,
+    VK_COVERAGE_REDUCTION_MODE_BEGIN_RANGE_NV = VK_COVERAGE_REDUCTION_MODE_MERGE_NV,
+    VK_COVERAGE_REDUCTION_MODE_END_RANGE_NV = VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV,
+    VK_COVERAGE_REDUCTION_MODE_RANGE_SIZE_NV = (VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV - VK_COVERAGE_REDUCTION_MODE_MERGE_NV + 1),
+    VK_COVERAGE_REDUCTION_MODE_MAX_ENUM_NV = 0x7FFFFFFF
+} VkCoverageReductionModeNV;
+typedef VkFlags VkPipelineCoverageReductionStateCreateFlagsNV;
+typedef struct VkPhysicalDeviceCoverageReductionModeFeaturesNV {
+    VkStructureType    sType;
+    void*              pNext;
+    VkBool32           coverageReductionMode;
+} VkPhysicalDeviceCoverageReductionModeFeaturesNV;
+
+typedef struct VkPipelineCoverageReductionStateCreateInfoNV {
+    VkStructureType                                  sType;
+    const void*                                      pNext;
+    VkPipelineCoverageReductionStateCreateFlagsNV    flags;
+    VkCoverageReductionModeNV                        coverageReductionMode;
+} VkPipelineCoverageReductionStateCreateInfoNV;
+
+typedef struct VkFramebufferMixedSamplesCombinationNV {
+    VkStructureType              sType;
+    void*                        pNext;
+    VkCoverageReductionModeNV    coverageReductionMode;
+    VkSampleCountFlagBits        rasterizationSamples;
+    VkSampleCountFlags           depthStencilSamples;
+    VkSampleCountFlags           colorSamples;
+} VkFramebufferMixedSamplesCombinationNV;
+
+typedef VkResult (VKAPI_PTR *PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV)(VkPhysicalDevice physicalDevice, uint32_t* pCombinationCount, VkFramebufferMixedSamplesCombinationNV* pCombinations);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pCombinationCount,
+    VkFramebufferMixedSamplesCombinationNV*     pCombinations);
 #endif
 
 

--- a/registry/conventions.py
+++ b/registry/conventions.py
@@ -17,8 +17,9 @@
 # Base class for working-group-specific style conventions,
 # used in generation.
 
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 
+ABC = ABCMeta('ABC', (object,), {})
 
 class ConventionsBase(ABC):
     """WG-specific conventions."""

--- a/registry/validusage.json
+++ b/registry/validusage.json
@@ -1,9 +1,9 @@
 {
   "version info": {
     "schema version": 2,
-    "api version": "1.1.107",
-    "comment": "from git branch: github-master commit: 5abf83f95d89cf6ba104b4c70d42d5c7c678b630",
-    "date": "2019-04-16 12:20:14Z"
+    "api version": "1.1.108",
+    "comment": "from git branch: github-master commit: 40ba6e9a4468915aa3aef2ccc153d60e7988193f",
+    "date": "2019-05-13 08:50:25Z"
   },
   "validation": {
     "vkGetInstanceProcAddr": {
@@ -362,7 +362,7 @@
         },
         {
           "vuid": "VUID-VkDeviceCreateInfo-pNext-pNext",
-          "text": " Each <code>pNext</code> member of any structure (including this one) in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be either <code>NULL</code> or a pointer to a valid instance of <a href=\"#VkDeviceGroupDeviceCreateInfo\">VkDeviceGroupDeviceCreateInfo</a>, <a href=\"#VkDeviceMemoryOverallocationCreateInfoAMD\">VkDeviceMemoryOverallocationCreateInfoAMD</a>, <a href=\"#VkPhysicalDevice16BitStorageFeatures\">VkPhysicalDevice16BitStorageFeatures</a>, <a href=\"#VkPhysicalDevice8BitStorageFeaturesKHR\">VkPhysicalDevice8BitStorageFeaturesKHR</a>, <a href=\"#VkPhysicalDeviceASTCDecodeFeaturesEXT\">VkPhysicalDeviceASTCDecodeFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT\">VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceBufferDeviceAddressFeaturesEXT\">VkPhysicalDeviceBufferDeviceAddressFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceComputeShaderDerivativesFeaturesNV\">VkPhysicalDeviceComputeShaderDerivativesFeaturesNV</a>, <a href=\"#VkPhysicalDeviceConditionalRenderingFeaturesEXT\">VkPhysicalDeviceConditionalRenderingFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceCooperativeMatrixFeaturesNV\">VkPhysicalDeviceCooperativeMatrixFeaturesNV</a>, <a href=\"#VkPhysicalDeviceCornerSampledImageFeaturesNV\">VkPhysicalDeviceCornerSampledImageFeaturesNV</a>, <a href=\"#VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV\">VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV</a>, <a href=\"#VkPhysicalDeviceDepthClipEnableFeaturesEXT\">VkPhysicalDeviceDepthClipEnableFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceDescriptorIndexingFeaturesEXT\">VkPhysicalDeviceDescriptorIndexingFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceExclusiveScissorFeaturesNV\">VkPhysicalDeviceExclusiveScissorFeaturesNV</a>, <a href=\"#VkPhysicalDeviceFeatures2\">VkPhysicalDeviceFeatures2</a>, <a href=\"#VkPhysicalDeviceFloat16Int8FeaturesKHR\">VkPhysicalDeviceFloat16Int8FeaturesKHR</a>, <a href=\"#VkPhysicalDeviceFragmentDensityMapFeaturesEXT\">VkPhysicalDeviceFragmentDensityMapFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV\">VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV</a>, <a href=\"#VkPhysicalDeviceHostQueryResetFeaturesEXT\">VkPhysicalDeviceHostQueryResetFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceInlineUniformBlockFeaturesEXT\">VkPhysicalDeviceInlineUniformBlockFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceMemoryPriorityFeaturesEXT\">VkPhysicalDeviceMemoryPriorityFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceMeshShaderFeaturesNV\">VkPhysicalDeviceMeshShaderFeaturesNV</a>, <a href=\"#VkPhysicalDeviceMultiviewFeatures\">VkPhysicalDeviceMultiviewFeatures</a>, <a href=\"#VkPhysicalDeviceProtectedMemoryFeatures\">VkPhysicalDeviceProtectedMemoryFeatures</a>, <a href=\"#VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV\">VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV</a>, <a href=\"#VkPhysicalDeviceSamplerYcbcrConversionFeatures\">VkPhysicalDeviceSamplerYcbcrConversionFeatures</a>, <a href=\"#VkPhysicalDeviceScalarBlockLayoutFeaturesEXT\">VkPhysicalDeviceScalarBlockLayoutFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceShaderAtomicInt64FeaturesKHR\">VkPhysicalDeviceShaderAtomicInt64FeaturesKHR</a>, <a href=\"#VkPhysicalDeviceShaderDrawParametersFeatures\">VkPhysicalDeviceShaderDrawParametersFeatures</a>, <a href=\"#VkPhysicalDeviceShaderImageFootprintFeaturesNV\">VkPhysicalDeviceShaderImageFootprintFeaturesNV</a>, <a href=\"#VkPhysicalDeviceShadingRateImageFeaturesNV\">VkPhysicalDeviceShadingRateImageFeaturesNV</a>, <a href=\"#VkPhysicalDeviceTransformFeedbackFeaturesEXT\">VkPhysicalDeviceTransformFeedbackFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceVariablePointersFeatures\">VkPhysicalDeviceVariablePointersFeatures</a>, <a href=\"#VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT\">VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceVulkanMemoryModelFeaturesKHR\">VkPhysicalDeviceVulkanMemoryModelFeaturesKHR</a>, or <a href=\"#VkPhysicalDeviceYcbcrImageArraysFeaturesEXT\">VkPhysicalDeviceYcbcrImageArraysFeaturesEXT</a>"
+          "text": " Each <code>pNext</code> member of any structure (including this one) in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be either <code>NULL</code> or a pointer to a valid instance of <a href=\"#VkDeviceGroupDeviceCreateInfo\">VkDeviceGroupDeviceCreateInfo</a>, <a href=\"#VkDeviceMemoryOverallocationCreateInfoAMD\">VkDeviceMemoryOverallocationCreateInfoAMD</a>, <a href=\"#VkPhysicalDevice16BitStorageFeatures\">VkPhysicalDevice16BitStorageFeatures</a>, <a href=\"#VkPhysicalDevice8BitStorageFeaturesKHR\">VkPhysicalDevice8BitStorageFeaturesKHR</a>, <a href=\"#VkPhysicalDeviceASTCDecodeFeaturesEXT\">VkPhysicalDeviceASTCDecodeFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT\">VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceBufferDeviceAddressFeaturesEXT\">VkPhysicalDeviceBufferDeviceAddressFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceComputeShaderDerivativesFeaturesNV\">VkPhysicalDeviceComputeShaderDerivativesFeaturesNV</a>, <a href=\"#VkPhysicalDeviceConditionalRenderingFeaturesEXT\">VkPhysicalDeviceConditionalRenderingFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceCooperativeMatrixFeaturesNV\">VkPhysicalDeviceCooperativeMatrixFeaturesNV</a>, <a href=\"#VkPhysicalDeviceCornerSampledImageFeaturesNV\">VkPhysicalDeviceCornerSampledImageFeaturesNV</a>, <a href=\"#VkPhysicalDeviceCoverageReductionModeFeaturesNV\">VkPhysicalDeviceCoverageReductionModeFeaturesNV</a>, <a href=\"#VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV\">VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV</a>, <a href=\"#VkPhysicalDeviceDepthClipEnableFeaturesEXT\">VkPhysicalDeviceDepthClipEnableFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceDescriptorIndexingFeaturesEXT\">VkPhysicalDeviceDescriptorIndexingFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceExclusiveScissorFeaturesNV\">VkPhysicalDeviceExclusiveScissorFeaturesNV</a>, <a href=\"#VkPhysicalDeviceFeatures2\">VkPhysicalDeviceFeatures2</a>, <a href=\"#VkPhysicalDeviceFloat16Int8FeaturesKHR\">VkPhysicalDeviceFloat16Int8FeaturesKHR</a>, <a href=\"#VkPhysicalDeviceFragmentDensityMapFeaturesEXT\">VkPhysicalDeviceFragmentDensityMapFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV\">VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV</a>, <a href=\"#VkPhysicalDeviceHostQueryResetFeaturesEXT\">VkPhysicalDeviceHostQueryResetFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceInlineUniformBlockFeaturesEXT\">VkPhysicalDeviceInlineUniformBlockFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceMemoryPriorityFeaturesEXT\">VkPhysicalDeviceMemoryPriorityFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceMeshShaderFeaturesNV\">VkPhysicalDeviceMeshShaderFeaturesNV</a>, <a href=\"#VkPhysicalDeviceMultiviewFeatures\">VkPhysicalDeviceMultiviewFeatures</a>, <a href=\"#VkPhysicalDeviceProtectedMemoryFeatures\">VkPhysicalDeviceProtectedMemoryFeatures</a>, <a href=\"#VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV\">VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV</a>, <a href=\"#VkPhysicalDeviceSamplerYcbcrConversionFeatures\">VkPhysicalDeviceSamplerYcbcrConversionFeatures</a>, <a href=\"#VkPhysicalDeviceScalarBlockLayoutFeaturesEXT\">VkPhysicalDeviceScalarBlockLayoutFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceShaderAtomicInt64FeaturesKHR\">VkPhysicalDeviceShaderAtomicInt64FeaturesKHR</a>, <a href=\"#VkPhysicalDeviceShaderDrawParametersFeatures\">VkPhysicalDeviceShaderDrawParametersFeatures</a>, <a href=\"#VkPhysicalDeviceShaderImageFootprintFeaturesNV\">VkPhysicalDeviceShaderImageFootprintFeaturesNV</a>, <a href=\"#VkPhysicalDeviceShadingRateImageFeaturesNV\">VkPhysicalDeviceShadingRateImageFeaturesNV</a>, <a href=\"#VkPhysicalDeviceTransformFeedbackFeaturesEXT\">VkPhysicalDeviceTransformFeedbackFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR\">VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR</a>, <a href=\"#VkPhysicalDeviceVariablePointersFeatures\">VkPhysicalDeviceVariablePointersFeatures</a>, <a href=\"#VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT\">VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT</a>, <a href=\"#VkPhysicalDeviceVulkanMemoryModelFeaturesKHR\">VkPhysicalDeviceVulkanMemoryModelFeaturesKHR</a>, or <a href=\"#VkPhysicalDeviceYcbcrImageArraysFeaturesEXT\">VkPhysicalDeviceYcbcrImageArraysFeaturesEXT</a>"
         },
         {
           "vuid": "VUID-VkDeviceCreateInfo-sType-unique",
@@ -5501,6 +5501,12 @@
           "text": " If the <code>VK_NV_framebuffer_mixed_samples</code> extension is enabled, and if <code>subpass</code> has any color attachments, then the <code>rasterizationSamples</code> member of <code>pMultisampleState</code> <strong class=\"purple\">must</strong> be greater than or equal to the sample count for those subpass attachments"
         }
       ],
+      "(VK_NV_coverage_reduction_mode)": [
+        {
+          "vuid": "VUID-VkGraphicsPipelineCreateInfo-coverageReductionMode-02722",
+          "text": " If the <code>VK_NV_coverage_reduction_mode</code> extension is enabled, the coverage reduction mode specified by <a href=\"#VkPipelineCoverageReductionStateCreateInfoNV\">VkPipelineCoverageReductionStateCreateInfoNV</a>::<code>coverageReductionMode</code>, the <code>rasterizationSamples</code> member of <code>pMultisampleState</code> and the sample counts for the color and depth/stencil attachments (if the subpass has them) <strong class=\"purple\">must</strong> be a valid combination returned by <code>vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV</code>"
+        }
+      ],
       "(VK_VERSION_1_1,VK_KHR_multiview)": [
         {
           "vuid": "VUID-VkGraphicsPipelineCreateInfo-renderPass-00760",
@@ -8473,12 +8479,12 @@
           "text": " If <code>subresourceRange</code>::<code>layerCount</code> is not <code>VK_REMAINING_ARRAY_LAYERS</code>, <code>image</code> is not a 3D image created with <code>VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT</code> set, or <code>viewType</code> is not <code>VK_IMAGE_VIEW_TYPE_2D</code> or <code>VK_IMAGE_VIEW_TYPE_2D_ARRAY</code>, <code>subresourceRange</code>::<code>layerCount</code> <strong class=\"purple\">must</strong> be non-zero and <span class=\"eq\"><code>subresourceRange</code>::<code>baseArrayLayer</code> &#43; <code>subresourceRange</code>::<code>layerCount</code></span> <strong class=\"purple\">must</strong> be less than or equal to the <code>arrayLayers</code> specified in <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> when <code>image</code> was created"
         },
         {
-          "vuid": "VUID-VkImageViewCreateInfo-image-01484",
-          "text": " If <code>image</code> is a 3D image created with <code>VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT</code> set, and <code>viewType</code> is <code>VK_IMAGE_VIEW_TYPE_2D</code> or <code>VK_IMAGE_VIEW_TYPE_2D_ARRAY</code>, <code>subresourceRange</code>::<code>baseArrayLayer</code> <strong class=\"purple\">must</strong> be less than the <code>extent.depth</code> specified in <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> when <code>image</code> was created"
+          "vuid": "VUID-VkImageViewCreateInfo-image-02724",
+          "text": " If <code>image</code> is a 3D image created with <code>VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT</code> set, and <code>viewType</code> is <code>VK_IMAGE_VIEW_TYPE_2D</code> or <code>VK_IMAGE_VIEW_TYPE_2D_ARRAY</code>, <code>subresourceRange</code>::<code>baseArrayLayer</code> <strong class=\"purple\">must</strong> be less than the depth computed from <code>baseMipLevel</code> and <code>extent.depth</code> specified in <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> when <code>image</code> was created, according to the formula defined in <a href=\"#resources-image-miplevel-sizing\">Image Miplevel Sizing</a>."
         },
         {
-          "vuid": "VUID-VkImageViewCreateInfo-subresourceRange-01485",
-          "text": " If <code>subresourceRange</code>::<code>layerCount</code> is not <code>VK_REMAINING_ARRAY_LAYERS</code>, <code>image</code> is a 3D image created with <code>VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT</code> set, and <code>viewType</code> is <code>VK_IMAGE_VIEW_TYPE_2D</code> or <code>VK_IMAGE_VIEW_TYPE_2D_ARRAY</code>, <code>subresourceRange</code>::<code>layerCount</code> <strong class=\"purple\">must</strong> be non-zero and <span class=\"eq\"><code>subresourceRange</code>::<code>baseArrayLayer</code> &#43; <code>subresourceRange</code>::<code>layerCount</code></span> <strong class=\"purple\">must</strong> be less than or equal to the <code>extent.depth</code> specified in <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> when <code>image</code> was created"
+          "vuid": "VUID-VkImageViewCreateInfo-subresourceRange-02725",
+          "text": " If <code>subresourceRange</code>::<code>layerCount</code> is not <code>VK_REMAINING_ARRAY_LAYERS</code>, <code>image</code> is a 3D image created with <code>VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT</code> set, and <code>viewType</code> is <code>VK_IMAGE_VIEW_TYPE_2D</code> or <code>VK_IMAGE_VIEW_TYPE_2D_ARRAY</code>, <code>subresourceRange</code>::<code>layerCount</code> <strong class=\"purple\">must</strong> be non-zero and <span class=\"eq\"><code>subresourceRange</code>::<code>baseArrayLayer</code> &#43; <code>subresourceRange</code>::<code>layerCount</code></span> <strong class=\"purple\">must</strong> be less than or equal to the depth computed from <code>baseMipLevel</code> and <code>extent.depth</code> specified in <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> when <code>image</code> was created, according to the formula defined in <a href=\"#resources-image-miplevel-sizing\">Image Miplevel Sizing</a>."
         }
       ],
       "!(VK_EXT_fragment_density_map)+!(VK_NV_shading_rate_image)": [
@@ -8607,13 +8613,13 @@
           "text": " If <code>image</code> was created with <code>usage</code> containing <code>VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV</code>, <code>format</code> <strong class=\"purple\">must</strong> be <code>VK_FORMAT_R8_UINT</code>"
         }
       ],
-      "!(VK_EXT_separate_stencil_usage)": [
+      "(VK_VERSION_1_1,VK_KHR_maintenance2)+!(VK_EXT_separate_stencil_usage)": [
         {
           "vuid": "VUID-VkImageViewCreateInfo-pNext-02661",
           "text": " If the <code>pNext</code> chain includes an instance of <a href=\"#VkImageViewUsageCreateInfo\">VkImageViewUsageCreateInfo</a>, its <code>usage</code> member <strong class=\"purple\">must</strong> not include any bits that were not set in the <code>usage</code> member of the <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> structure used to create <code>image</code>."
         }
       ],
-      "(VK_EXT_separate_stencil_usage)": [
+      "(VK_VERSION_1_1,VK_KHR_maintenance2)+(VK_EXT_separate_stencil_usage)": [
         {
           "vuid": "VUID-VkImageViewCreateInfo-pNext-02662",
           "text": " If the <code>pNext</code> chain includes an instance of <a href=\"#VkImageViewUsageCreateInfo\">VkImageViewUsageCreateInfo</a>, and <code>image</code> was not created with an instance of <a href=\"#VkImageStencilUsageCreateInfoEXT\">VkImageStencilUsageCreateInfoEXT</a> in the <code>pNext</code> chain of <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a>, its <code>usage</code> member <strong class=\"purple\">must</strong> not include any bits that were not set in the <code>usage</code> member of the <a href=\"#VkImageCreateInfo\">VkImageCreateInfo</a> structure used to create <code>image</code>"
@@ -9074,6 +9080,16 @@
           "vuid": "VUID-vkBindBufferMemory-buffer-01039",
           "text": " If <code>buffer</code> was not created with <a href=\"#VkDedicatedAllocationBufferCreateInfoNV\">VkDedicatedAllocationBufferCreateInfoNV</a>::<code>dedicatedAllocation</code> equal to <code>VK_TRUE</code>, <code>memory</code> <strong class=\"purple\">must</strong> not have been allocated dedicated for a specific buffer or image"
         }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_external_memory)": [
+        {
+          "vuid": "VUID-vkBindBufferMemory-memory-02726",
+          "text": " If <code>memory</code> was allocated with <a href=\"#VkExportMemoryAllocateInfo\">VkExportMemoryAllocateInfo</a>::<code>handleTypes</code> not equal to <code>0</code>, at least one handle type it contained must also have been set in <a href=\"#VkExternalMemoryBufferCreateInfo\">VkExternalMemoryBufferCreateInfo</a>::<code>handleTypes</code> when <code>buffer</code> was created."
+        },
+        {
+          "vuid": "VUID-vkBindBufferMemory-memory-02727",
+          "text": " If <code>memory</code> was created by a memory import operation, the external handle type of the imported memory must also have been set in <a href=\"#VkExternalMemoryBufferCreateInfo\">VkExternalMemoryBufferCreateInfo</a>::<code>handleTypes</code> when <code>buffer</code> was created."
+        }
       ]
     },
     "vkBindBufferMemory2": {
@@ -9283,6 +9299,16 @@
         {
           "vuid": "VUID-vkBindImageMemory-image-01051",
           "text": " If <code>image</code> was not created with <a href=\"#VkDedicatedAllocationImageCreateInfoNV\">VkDedicatedAllocationImageCreateInfoNV</a>::<code>dedicatedAllocation</code> equal to <code>VK_TRUE</code>, <code>memory</code> <strong class=\"purple\">must</strong> not have been allocated dedicated for a specific buffer or image"
+        }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_external_memory)": [
+        {
+          "vuid": "VUID-vkBindImageMemory-memory-02728",
+          "text": " If <code>memory</code> was allocated with <a href=\"#VkExportMemoryAllocateInfo\">VkExportMemoryAllocateInfo</a>::<code>handleTypes</code> not equal to <code>0</code>, at least one handle type it contained must also have been set in <a href=\"#VkExternalMemoryImageCreateInfo\">VkExternalMemoryImageCreateInfo</a>::<code>handleTypes</code> when <code>image</code> was created."
+        },
+        {
+          "vuid": "VUID-vkBindImageMemory-memory-02729",
+          "text": " If <code>memory</code> was created by a memory import operation, the external handle type of the imported memory must also have been set in <a href=\"#VkExternalMemoryImageCreateInfo\">VkExternalMemoryImageCreateInfo</a>::<code>handleTypes</code> when <code>image</code> was created."
         }
       ]
     },
@@ -12295,6 +12321,10 @@
           "text": " If the <code>queryType</code> used to create <code>queryPool</code> was not <code>VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT</code> the <code>index</code> <strong class=\"purple\">must</strong> be zero"
         },
         {
+          "vuid": "VUID-vkCmdEndQueryIndexedEXT-queryType-02723",
+          "text": " If the <code>queryType</code> used to create <code>queryPool</code> was <code>VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT</code> <code>index</code> <strong class=\"purple\">must</strong> equal the <code>index</code> used to begin the query"
+        },
+        {
           "vuid": "VUID-vkCmdEndQueryIndexedEXT-commandBuffer-parameter",
           "text": " <code>commandBuffer</code> <strong class=\"purple\">must</strong> be a valid <code>VkCommandBuffer</code> handle"
         },
@@ -12324,7 +12354,7 @@
       "(VK_EXT_transform_feedback)+(VK_VERSION_1_1,VK_KHR_multiview)": [
         {
           "vuid": "VUID-vkCmdEndQueryIndexedEXT-query-02345",
-          "text": " If <code>vkCmdEndQuery</code> is called within a render pass instance, the sum of <code>query</code> and the number of bits set in the current subpass&#8217;s view mask <strong class=\"purple\">must</strong> be less than or equal to the number of queries in <code>queryPool</code>"
+          "text": " If <code>vkCmdEndQueryIndexedEXT</code> is called within a render pass instance, the sum of <code>query</code> and the number of bits set in the current subpass&#8217;s view mask <strong class=\"purple\">must</strong> be less than or equal to the number of queries in <code>queryPool</code>"
         }
       ]
     },
@@ -17148,7 +17178,7 @@
         },
         {
           "vuid": "VUID-VkPipelineMultisampleStateCreateInfo-pNext-pNext",
-          "text": " Each <code>pNext</code> member of any structure (including this one) in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be either <code>NULL</code> or a pointer to a valid instance of <a href=\"#VkPipelineCoverageModulationStateCreateInfoNV\">VkPipelineCoverageModulationStateCreateInfoNV</a>, <a href=\"#VkPipelineCoverageToColorStateCreateInfoNV\">VkPipelineCoverageToColorStateCreateInfoNV</a>, or <a href=\"#VkPipelineSampleLocationsStateCreateInfoEXT\">VkPipelineSampleLocationsStateCreateInfoEXT</a>"
+          "text": " Each <code>pNext</code> member of any structure (including this one) in the <code>pNext</code> chain <strong class=\"purple\">must</strong> be either <code>NULL</code> or a pointer to a valid instance of <a href=\"#VkPipelineCoverageModulationStateCreateInfoNV\">VkPipelineCoverageModulationStateCreateInfoNV</a>, <a href=\"#VkPipelineCoverageReductionStateCreateInfoNV\">VkPipelineCoverageReductionStateCreateInfoNV</a>, <a href=\"#VkPipelineCoverageToColorStateCreateInfoNV\">VkPipelineCoverageToColorStateCreateInfoNV</a>, or <a href=\"#VkPipelineSampleLocationsStateCreateInfoEXT\">VkPipelineSampleLocationsStateCreateInfoEXT</a>"
         },
         {
           "vuid": "VUID-VkPipelineMultisampleStateCreateInfo-sType-unique",
@@ -18003,6 +18033,50 @@
         {
           "vuid": "VUID-VkPipelineCoverageToColorStateCreateInfoNV-flags-zerobitmask",
           "text": " <code>flags</code> <strong class=\"purple\">must</strong> be <code>0</code>"
+        }
+      ]
+    },
+    "VkPipelineCoverageReductionStateCreateInfoNV": {
+      "(VK_NV_framebuffer_mixed_samples)+(VK_NV_coverage_reduction_mode)": [
+        {
+          "vuid": "VUID-VkPipelineCoverageReductionStateCreateInfoNV-sType-sType",
+          "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV</code>"
+        },
+        {
+          "vuid": "VUID-VkPipelineCoverageReductionStateCreateInfoNV-flags-zerobitmask",
+          "text": " <code>flags</code> <strong class=\"purple\">must</strong> be <code>0</code>"
+        },
+        {
+          "vuid": "VUID-VkPipelineCoverageReductionStateCreateInfoNV-coverageReductionMode-parameter",
+          "text": " <code>coverageReductionMode</code> <strong class=\"purple\">must</strong> be a valid <a href=\"#VkCoverageReductionModeNV\">VkCoverageReductionModeNV</a> value"
+        }
+      ]
+    },
+    "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV": {
+      "(VK_NV_framebuffer_mixed_samples)+(VK_NV_coverage_reduction_mode)": [
+        {
+          "vuid": "VUID-vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV-physicalDevice-parameter",
+          "text": " <code>physicalDevice</code> <strong class=\"purple\">must</strong> be a valid <code>VkPhysicalDevice</code> handle"
+        },
+        {
+          "vuid": "VUID-vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV-pCombinationCount-parameter",
+          "text": " <code>pCombinationCount</code> <strong class=\"purple\">must</strong> be a valid pointer to a <code>uint32_t</code> value"
+        },
+        {
+          "vuid": "VUID-vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV-pCombinations-parameter",
+          "text": " If the value referenced by <code>pCombinationCount</code> is not <code>0</code>, and <code>pCombinations</code> is not <code>NULL</code>, <code>pCombinations</code> <strong class=\"purple\">must</strong> be a valid pointer to an array of <code>pCombinationCount</code> <code>VkFramebufferMixedSamplesCombinationNV</code> structures"
+        }
+      ]
+    },
+    "VkFramebufferMixedSamplesCombinationNV": {
+      "(VK_NV_framebuffer_mixed_samples)+(VK_NV_coverage_reduction_mode)": [
+        {
+          "vuid": "VUID-VkFramebufferMixedSamplesCombinationNV-sType-sType",
+          "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV</code>"
+        },
+        {
+          "vuid": "VUID-VkFramebufferMixedSamplesCombinationNV-pNext-pNext",
+          "text": " <code>pNext</code> <strong class=\"purple\">must</strong> be <code>NULL</code>"
         }
       ]
     },
@@ -19500,6 +19574,16 @@
           "vuid": "VUID-VkSparseMemoryBind-flags-parameter",
           "text": " <code>flags</code> <strong class=\"purple\">must</strong> be a valid combination of <a href=\"#VkSparseMemoryBindFlagBits\">VkSparseMemoryBindFlagBits</a> values"
         }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_external_memory)": [
+        {
+          "vuid": "VUID-VkSparseMemoryBind-memory-02730",
+          "text": " If <code>memory</code> was created with <a href=\"#VkExportMemoryAllocateInfo\">VkExportMemoryAllocateInfo</a>::<code>handleTypes</code> not equal to <code>0</code>, at least one handle type it contained must also have been set in <a href=\"#VkExternalMemoryBufferCreateInfo\">VkExternalMemoryBufferCreateInfo</a>::<code>handleTypes</code> or <a href=\"#VkExternalMemoryImageCreateInfo\">VkExternalMemoryImageCreateInfo</a>::<code>handleTypes</code> when the resource was created."
+        },
+        {
+          "vuid": "VUID-VkSparseMemoryBind-memory-02731",
+          "text": " If <code>memory</code> was created by a memory import operation, the external handle type of the imported memory must also have been set in <a href=\"#VkExternalMemoryBufferCreateInfo\">VkExternalMemoryBufferCreateInfo</a>::<code>handleTypes</code> or <a href=\"#VkExternalMemoryImageCreateInfo\">VkExternalMemoryImageCreateInfo</a>::<code>handleTypes</code> when the resource was created."
+        }
       ]
     },
     "VkSparseBufferMemoryBindInfo": {
@@ -19611,6 +19695,16 @@
         {
           "vuid": "VUID-VkSparseImageMemoryBind-flags-parameter",
           "text": " <code>flags</code> <strong class=\"purple\">must</strong> be a valid combination of <a href=\"#VkSparseMemoryBindFlagBits\">VkSparseMemoryBindFlagBits</a> values"
+        }
+      ],
+      "(VK_VERSION_1_1,VK_KHR_external_memory)": [
+        {
+          "vuid": "VUID-VkSparseImageMemoryBind-memory-02732",
+          "text": " If <code>memory</code> was created with <a href=\"#VkExportMemoryAllocateInfo\">VkExportMemoryAllocateInfo</a>::<code>handleTypes</code> not equal to <code>0</code>, at least one handle type it contained must also have been set in <a href=\"#VkExternalMemoryImageCreateInfo\">VkExternalMemoryImageCreateInfo</a>::<code>handleTypes</code> when the image was created."
+        },
+        {
+          "vuid": "VUID-VkSparseImageMemoryBind-memory-02733",
+          "text": " If <code>memory</code> was created by a memory import operation, the external handle type of the imported memory must also have been set in <a href=\"#VkExternalMemoryImageCreateInfo\">VkExternalMemoryImageCreateInfo</a>::<code>handleTypes</code> when <code>image</code> was created."
         }
       ]
     },
@@ -22634,6 +22728,14 @@
         }
       ]
     },
+    "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+      "(VK_KHR_uniform_buffer_standard_layout)": [
+        {
+          "vuid": "VUID-VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR-sType-sType",
+          "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR</code>"
+        }
+      ]
+    },
     "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
       "(VK_EXT_depth_clip_enable)": [
         {
@@ -22687,6 +22789,14 @@
         {
           "vuid": "VUID-VkPhysicalDeviceHostQueryResetFeaturesEXT-sType-sType",
           "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT</code>"
+        }
+      ]
+    },
+    "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+      "(VK_NV_coverage_reduction_mode)": [
+        {
+          "vuid": "VUID-VkPhysicalDeviceCoverageReductionModeFeaturesNV-sType-sType",
+          "text": " <code>sType</code> <strong class=\"purple\">must</strong> be <code>VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV</code>"
         }
       ]
     },

--- a/registry/vk.xml
+++ b/registry/vk.xml
@@ -153,7 +153,7 @@ server.
         <type category="define">// Vulkan 1.1 version number
 #define <name>VK_API_VERSION_1_1</name> <type>VK_MAKE_VERSION</type>(1, 1, 0)// Patch version should always be set to 0</type>
         <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 107</type>
+#define <name>VK_HEADER_VERSION</name> 108</type>
 
         <type category="define">
 #define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* object;</type>
@@ -318,6 +318,7 @@ typedef void <name>CAMetalLayer</name>;
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDiscardRectangleStateCreateFlagsEXT</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCoverageToColorStateCreateFlagsNV</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCoverageModulationStateCreateFlagsNV</name>;</type>
+        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCoverageReductionStateCreateFlagsNV</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkValidationCacheCreateFlagsEXT</name>;</type>
         <type requires="VkDebugUtilsMessageSeverityFlagBitsEXT"  category="bitmask">typedef <type>VkFlags</type> <name>VkDebugUtilsMessageSeverityFlagsEXT</name>;</type>
         <type requires="VkDebugUtilsMessageTypeFlagBitsEXT"      category="bitmask">typedef <type>VkFlags</type> <name>VkDebugUtilsMessageTypeFlagsEXT</name>;</type>
@@ -479,6 +480,7 @@ typedef void <name>CAMetalLayer</name>;
         <type name="VkPointClippingBehavior" category="enum"/>
         <type category="enum" name="VkPointClippingBehaviorKHR"                    alias="VkPointClippingBehavior"/>
         <type name="VkCoverageModulationModeNV" category="enum"/>
+        <type name="VkCoverageReductionModeNV" category="enum"/>
         <type name="VkValidationCacheHeaderVersionEXT" category="enum"/>
         <type name="VkShaderInfoTypeAMD" category="enum"/>
         <type name="VkQueueGlobalPriorityEXT" category="enum"/>
@@ -3738,6 +3740,11 @@ typedef void <name>CAMetalLayer</name>;
             <member>const <type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type> <name>supportsProtected</name><comment>Represents if surface can be protected</comment></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                               <name>pNext</name></member>
+            <member><type>VkBool32</type>                            <name>uniformBufferStandardLayout</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceDepthClipEnableFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member><type>void</type>*                  <name>pNext</name><comment>Pointer to next structure</comment></member>
@@ -3864,6 +3871,25 @@ typedef void <name>CAMetalLayer</name>;
             <member values="VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member>const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkHeadlessSurfaceCreateFlagsEXT</type>   <name>flags</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCoverageReductionModeFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV"><type>VkStructureType</type><name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type>                       <name>coverageReductionMode</name></member>
+        </type>
+        <type category="struct" name="VkPipelineCoverageReductionStateCreateInfoNV" structextends="VkPipelineMultisampleStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                                                        <name>pNext</name></member>
+            <member optional="true"><type>VkPipelineCoverageReductionStateCreateFlagsNV</type>      <name>flags</name></member>
+            <member><type>VkCoverageReductionModeNV</type>                                          <name>coverageReductionMode</name></member>
+        </type>
+        <type category="struct" name="VkFramebufferMixedSamplesCombinationNV" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member><type>void</type>*                      <name>pNext</name></member>
+            <member><type>VkCoverageReductionModeNV</type>  <name>coverageReductionMode</name></member>
+            <member><type>VkSampleCountFlagBits</type>      <name>rasterizationSamples</name></member>
+            <member><type>VkSampleCountFlags</type>         <name>depthStencilSamples</name></member>
+            <member><type>VkSampleCountFlags</type>         <name>colorSamples</name></member>
         </type>
     </types>
 
@@ -4933,6 +4959,10 @@ typedef void <name>CAMetalLayer</name>;
         <enum value="1"     name="VK_COVERAGE_MODULATION_MODE_RGB_NV"/>
         <enum value="2"     name="VK_COVERAGE_MODULATION_MODE_ALPHA_NV"/>
         <enum value="3"     name="VK_COVERAGE_MODULATION_MODE_RGBA_NV"/>
+    </enums>
+    <enums name="VkCoverageReductionModeNV" type="enum">
+        <enum value="0"     name="VK_COVERAGE_REDUCTION_MODE_MERGE_NV"/>
+        <enum value="1"     name="VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV"/>
     </enums>
     <enums name="VkValidationCacheHeaderVersionEXT" type="enum">
         <enum value="1"     name="VK_VALIDATION_CACHE_HEADER_VERSION_ONE_EXT"/>
@@ -7337,6 +7367,12 @@ typedef void <name>CAMetalLayer</name>;
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param><type>VkSurfaceKHR</type>* <name>pSurface</name></param>
         </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pCombinationCount</name></param>
+            <param optional="true" len="pCombinationCount"><type>VkFramebufferMixedSamplesCombinationNV</type>* <name>pCombinations</name></param>
+        </command>
     </commands>
 
     <feature api="vulkan" name="VK_VERSION_1_0" number="1.0" comment="Vulkan core API interface definitions">
@@ -8054,6 +8090,7 @@ typedef void <name>CAMetalLayer</name>;
         </extension>
         <extension name="VK_ANDROID_native_buffer" number="11" type="device" author="ANDROID" platform="android" contact="Jesse Hall @critsec" supported="disabled">
             <require>
+                <comment>VK_ANDROID_native_buffer is used between the Android Vulkan loader and drivers to implement the WSI extensions. It isn't exposed to applications and uses types that aren't part of Android's stable public API, so it is left disabled to keep it out of the standard Vulkan headers.</comment>
                 <enum value="5"                                                 name="VK_ANDROID_NATIVE_BUFFER_SPEC_VERSION"/>
                 <enum value="11"                                                name="VK_ANDROID_NATIVE_BUFFER_NUMBER"/>
                 <enum value="&quot;VK_ANDROID_native_buffer&quot;"              name="VK_ANDROID_NATIVE_BUFFER_NAME"/>
@@ -8582,9 +8619,6 @@ typedef void <name>CAMetalLayer</name>;
                 <type name="VkDeviceGroupPresentInfoKHR"/>
                 <type name="VkDeviceGroupSwapchainCreateInfoKHR"/>
                 <command name="vkAcquireNextImage2KHR"/>
-            </require>
-            <require extension="VK_EXT_full_screen_exclusive">
-                <command name="vkGetDeviceGroupSurfacePresentModes2EXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_validation_flags" number="62" type="instance" author="GOOGLE" contact="Tobin Ehlis @tobine" supported="vulkan">
@@ -9118,11 +9152,11 @@ typedef void <name>CAMetalLayer</name>;
         </extension>
         <extension name="VK_EXT_swapchain_colorspace" number="105" type="instance" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" requires="VK_KHR_surface" supported="vulkan">
             <require>
-                <enum value="3"                                             name="VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION"/>
+                <enum value="4"                                             name="VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_swapchain_colorspace&quot;"       name="VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME"/>
                 <enum offset="1" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT"/>
                 <enum offset="2" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT"/>
-                <enum offset="3" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT"/>
+                <enum offset="3" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT"/>
                 <enum offset="4" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT"/>
                 <enum offset="5" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_BT709_LINEAR_EXT"/>
                 <enum offset="6" extends="VkColorSpaceKHR"                  name="VK_COLOR_SPACE_BT709_NONLINEAR_EXT"/>
@@ -9134,6 +9168,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum offset="12" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT"/>
                 <enum offset="13" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_PASS_THROUGH_EXT"/>
                 <enum offset="14" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT"/>
+                <enum extends="VkColorSpaceKHR" name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT" alias="VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT" comment="Deprecated name for backwards compatibility"/>
             </require>
         </extension>
         <extension name="VK_EXT_hdr_metadata" number="106" type="device" requires="VK_KHR_swapchain" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" supported="vulkan">
@@ -10665,10 +10700,19 @@ typedef void <name>CAMetalLayer</name>;
                 <command name="vkGetPhysicalDeviceCooperativeMatrixPropertiesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_251" number="251" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="disabled">
+        <extension name="VK_NV_coverage_reduction_mode" number="251" requires="VK_NV_framebuffer_mixed_samples" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_NV_EXTENSION_251_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_251&quot;"               name="VK_NV_EXTENSION_251_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_NV_COVERAGE_REDUCTION_MODE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_coverage_reduction_mode&quot;"     name="VK_NV_COVERAGE_REDUCTION_MODE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV"/>
+                <type name="VkPhysicalDeviceCoverageReductionModeFeaturesNV"/>
+                <type name="VkPipelineCoverageReductionStateCreateInfoNV"/>
+                <type name="VkPipelineCoverageReductionStateCreateFlagsNV"/>
+                <type name="VkCoverageReductionModeNV"/>
+                <type name="VkFramebufferMixedSamplesCombinationNV"/>
+                <command name="vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_252" number="252" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="disabled">
@@ -10685,10 +10729,12 @@ typedef void <name>CAMetalLayer</name>;
                 <type name="VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_254" number="254" author="EXT" contact="Graeme Leese @gnl21" supported="disabled">
+        <extension name="VK_KHR_uniform_buffer_standard_layout" number="254" requires="VK_KHR_get_physical_device_properties2" type="device" author="KHR" contact="Graeme Leese @gnl21" supported="vulkan">
             <require>
-                <enum value="1"                                             name="VK_EXT_EXTENSION_254_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_254&quot;"              name="VK_EXT_EXTENSION_254_EXTENSION_NAME"/>
+                <enum value="1"                                                 name="VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_uniform_buffer_standard_layout&quot;" name="VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME"/>
+                <type                                                           name="VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"/>
+                <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_255" number="255" author="EXT" contact="Jesse Hall @jessehall" supported="disabled">
@@ -10714,6 +10760,9 @@ typedef void <name>CAMetalLayer</name>;
             <require extension="VK_KHR_win32_surface">
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT"/>
                 <type name="VkSurfaceFullScreenExclusiveWin32InfoEXT"/>
+            </require>
+            <require extension="VK_KHR_device_group">
+                <command name="vkGetDeviceGroupSurfacePresentModes2EXT"/>
             </require>
             <require feature="VK_VERSION_1_1">
                 <command name="vkGetDeviceGroupSurfacePresentModes2EXT"/>
@@ -10760,6 +10809,48 @@ typedef void <name>CAMetalLayer</name>;
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT"/>
                 <type name="VkPhysicalDeviceHostQueryResetFeaturesEXT"/>
                 <command name="vkResetQueryPoolEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_GGP_extension_263" number="263" author="GGP" contact="Jean-Francois Roy @jfroy" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_GOOGLE_EXTENSION_263_SPEC_VERSION"/>
+                <enum value="&quot;VK_GGP_extension_263&quot;"              name="VK_GOOGLE_EXTENSION_263_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_BRCM_extension_264" number="264" author="BRCM" contact="Graeme Leese @gnl21" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_BRCM_EXTENSION_264_SPEC_VERSION"/>
+                <enum value="&quot;VK_BRCM_extension_264&quot;"             name="VK_BRCM_EXTENSION_264_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_BRCM_extension_265" number="265" author="BRCM" contact="Graeme Leese @gnl21" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_BRCM_EXTENSION_265_SPEC_VERSION"/>
+                <enum value="&quot;VK_BRCM_extension_265&quot;"             name="VK_BRCM_EXTENSION_265_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_266" number="266" type="device" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_266_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_266&quot;"              name="VK_EXT_extension_266"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_267" number="267" type="device" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_267_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_267&quot;"              name="VK_EXT_extension_267"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_268" number="268" type="device" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_268_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_268&quot;"              name="VK_EXT_extension_268"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_269" number="269" type="device" author="KHR" contact="Josh Barczak @jbarczak" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_269_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_269&quot;"              name="VK_KHR_extension_269"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
This updates the C headers to tag v1.1.108 from the Vulkan-Docs repo, but there's another build issue with VulkanHppGenerator:

> % (cd build && ./VulkanHppGenerator)
> Loading vk.xml from /home/tree/git/Vulkan-Hpp/Vulkan-Docs/xml/vk.xml
> Writing vulkan.hpp to /home/tree/git/Vulkan-Hpp/vulkan/vulkan.hpp
> warning: Unknown element in spec on line: 8093 comment!
> VulkanHppGenerator: /home/tree/git/Vulkan-Hpp/VulkanHppGenerator.cpp:1463: void VulkanHppGenerator::readExtensionDisabledRequire(const tinyxml2::XMLElement*): Assertion `value == "enum"' failed.
> Abort

I opened https://github.com/KhronosGroup/Vulkan-Hpp/issues/329 to get this resolved.