### PR TITLE
Fix typo.

### DIFF
--- a/include/vulkan/vulkan.hpp
+++ b/include/vulkan/vulkan.hpp
@@ -100,7 +100,7 @@ static_assert( VK_HEADER_VERSION ==  116 , "Wrong VK_HEADER_VERSION!" );
 #endif
 
 #if !defined(VULKAN_HPP_INLINE)
-# if defined(__clang___)
+# if defined(__clang__)
 #  if __has_attribute(always_inline)
 #   define VULKAN_HPP_INLINE __attribute__((always_inline)) __inline__
 #  else


### PR DESCRIPTION
I think this is supposed to be `__clang__` and not `__clang___` as seen in elsewhere in the repo and in online documentation.