### PR TITLE
Add metal surface support to ICD header

### DIFF
--- a/include/vulkan/vk_icd.h
+++ b/include/vulkan/vk_icd.h
@@ -89,7 +89,8 @@ typedef enum {
     VK_ICD_WSI_PLATFORM_MACOS,
     VK_ICD_WSI_PLATFORM_IOS,
     VK_ICD_WSI_PLATFORM_DISPLAY,
-    VK_ICD_WSI_PLATFORM_HEADLESS
+    VK_ICD_WSI_PLATFORM_HEADLESS,
+    VK_ICD_WSI_PLATFORM_METAL,
 } VkIcdWsiPlatform;
 
 typedef struct {
@@ -171,5 +172,12 @@ typedef struct {
 typedef struct {
     VkIcdSurfaceBase base;
 } VkIcdSurfaceHeadless;
+
+#ifdef VK_USE_PLATFORM_METAL_EXT
+typedef struct {
+    VkIcdSurfaceBase base;
+    const CAMetalLayer *pLayer;
+} VkIcdSurfaceMetal;
+#endif // VK_USE_PLATFORM_METAL_EXT
 
 #endif  // VKICD_H


### PR DESCRIPTION
In order to properly support the `VK_EXT_metal_surface` extension, the loader needs a metal surface structure in `vk_icd.h`. This PR adds that structure.