### PR TITLE
build: BUILD.gn missing defines for MacOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -28,6 +28,9 @@ config("vulkan_headers_config") {
   if (is_fuchsia) {
     defines = [ "VK_USE_PLATFORM_FUCHSIA" ]
   }
+  if (is_mac) {
+    defines = [ "VK_USE_PLATFORM_METAL_EXT" ]
+  }
 }
 
 # Vulkan headers only, no compiled sources.


### PR DESCRIPTION
BUILD.gn does not define VK_USE_PLATFORM_MACOS_MVK for MacOS