### PR TITLE
Export CMake targets file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ cmake_minimum_required(VERSION 3.10.2)
 
 # NONE = this project has no language toolchain requirement.
 project(Vulkan-Headers NONE)
+set(VERSION_STRING "1.1.127")
+
+option(VULKAN_HEADERS_SKIP_INSTALL "Skip install" OFF)
 
 # User-interface declarations ----------------------------------------------------------------------------------------------------
 # This section contains variables that affect development GUIs (e.g. CMake GUI and IDEs), such as option(), folders, and variables
@@ -38,21 +41,72 @@ endif()
 
 # define exported targets for nested project builds to consume
 add_library(Vulkan-Headers INTERFACE)
-target_include_directories(Vulkan-Headers INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(Vulkan-Headers INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 add_library(Vulkan::Headers ALIAS Vulkan-Headers)
 
 add_library(Vulkan-Registry INTERFACE)
-target_include_directories(Vulkan-Registry INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/registry")
+target_include_directories(Vulkan-Registry INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/registry>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_DATADIR}/vulkan>
+)
 add_library(Vulkan::Registry ALIAS Vulkan-Registry)
 
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${CMAKE_INSTALL_DATADIR}/vulkan)
+# Installation
+if(NOT VULKAN_HEADERS_SKIP_INSTALL)
+  set(config_install_dir "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/cmake")
+  
+  set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+  
+  set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+  set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+  set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+  set(namespace "${PROJECT_NAME}::")
+  
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(
+      "${version_config}"
+      VERSION ${VERSION_STRING}
+      COMPATIBILITY AnyNewerVersion
+  )
+  
+  configure_package_config_file(
+      "cmake/Config.cmake.in"
+      "${project_config}"
+      INSTALL_DESTINATION "${config_install_dir}"
+  )
+  
+  install(
+      TARGETS Vulkan-Headers Vulkan-Registry
+      EXPORT "${TARGETS_EXPORT_NAME}"
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+  
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${CMAKE_INSTALL_DATADIR}/vulkan)
+  
+  install(
+      FILES "${project_config}" "${version_config}"
+      DESTINATION "${config_install_dir}"
+  )
+  
+  install(
+      EXPORT "${TARGETS_EXPORT_NAME}"
+      NAMESPACE "${namespace}"
+      DESTINATION "${config_install_dir}"
+  )
 
-# uninstall target
-if(NOT TARGET uninstall)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-                   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-                   IMMEDIATE
-                   @ONLY)
-    add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+  # uninstall target
+  if(NOT TARGET uninstall)
+      configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+                     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+                     IMMEDIATE
+                     @ONLY)
+      add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+  endif()
 endif()

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,25 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")
+
+# ALIAS for imported target requires CMake >= 3.11:
+# - https://cmake.org/cmake/help/latest/release/3.11.html#other
+if(NOT CMAKE_VERSION VERSION_LESS 3.11)
+  if(NOT TARGET Vulkan::Headers)
+    set_target_properties(
+      @PROJECT_NAME@::Vulkan-Headers
+      PROPERTIES
+      IMPORTED_GLOBAL True
+    )
+    add_library(Vulkan::Headers ALIAS @PROJECT_NAME@::Vulkan-Headers)
+  endif()
+  if(NOT TARGET Vulkan::Registry)
+    set_target_properties(
+      @PROJECT_NAME@::Vulkan-Registry
+      PROPERTIES
+      IMPORTED_GLOBAL True
+    )
+    add_library(Vulkan::Registry ALIAS @PROJECT_NAME@::Vulkan-Registry)
+  endif()
+endif()


### PR DESCRIPTION
Similar to https://github.com/KhronosGroup/SPIRV-Headers/pull/105

This change generates and installs the following files onto the system

```
-- Installing: /usr/local/lib/cmake/Vulkan-Headers/Vulkan-HeadersConfig.cmake
-- Installing: /usr/local/lib/cmake/Vulkan-Headers/Vulkan-HeadersConfigVersion.cmake
-- Installing: /usr/local/lib/cmake/Vulkan-Headers/Vulkan-HeadersTargets.cmake
```

which makes Vulkan-Headers discoverable after installation by other cmake projects via find_package:

```cmake
find_package(Vulkan-Headers 1.1.127 CONFIG REQUIRED)
```

Also, similar to https://github.com/KhronosGroup/SPIRV-Headers/pull/131 I have added an option to disable installation.