### PR TITLE
GN: Make PLATFORM_XCB optional, based on a user-defined variable.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -13,13 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/vulkan_headers.gni")
+
 config("vulkan_headers_config") {
   include_dirs = [ "include" ]
 
   if (is_win) {
     defines = [ "VK_USE_PLATFORM_WIN32_KHR" ]
   }
-  if (is_linux) {
+  if (defined(vulkan_use_x11) && vulkan_use_x11) {
     defines = [ "VK_USE_PLATFORM_XCB_KHR" ]
   }
   if (is_android) {


### PR DESCRIPTION
Not all Linux platforms will have X11 available (Wayland, GGP), so we have to declare a variable that checks use_x11 separately.

This depends on an ANGLE bug: https://bugs.chromium.org/p/angleproject/issues/detail?id=4116