### PR TITLE
build: Clarify Windows build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -73,9 +73,9 @@ directories and place them in any location.
   - Any Personal Computer version supported by Microsoft
 - Microsoft [Visual Studio](https://www.visualstudio.com/)
   - Versions
-    - [2013 (update 4)](https://www.visualstudio.com/vs/older-downloads/)
     - [2015](https://www.visualstudio.com/vs/older-downloads/)
-    - [2017](https://www.visualstudio.com/vs/downloads/)
+    - [2017](https://www.visualstudio.com/vs/older-downloads/)
+    - [2019](https://www.visualstudio.com/vs/downloads/)
   - The Community Edition of each of the above versions is sufficient, as
     well as any more capable edition.
 - [CMake 3.10.2](https://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.zip) is recommended.
@@ -96,6 +96,8 @@ work with the solution interactively.
 
 #### Windows Quick Start
 
+From a "Developer Command Prompt for VS 201x" console:
+
     cd Vulkan-Headers
     mkdir build
     cd build
@@ -106,8 +108,9 @@ See below for the details.
 
 #### Use `CMake` to Create the Visual Studio Project Files
 
-Change your current directory to the top of the cloned repository directory,
-create a build directory and generate the Visual Studio project files:
+From within a "Developer Command Prompt for VS 201x" console, change your
+current directory to the top of the cloned repository directory, create a
+build directory and generate the Visual Studio project files:
 
     cd Vulkan-Headers
     mkdir build


### PR DESCRIPTION
It was not specified that the windows commands must be run from within a developer console.
Also removed VS2013 and added VS2019 refs.

Would have helped with #92.