### PR TITLE
Guard against multiple NOMINMAX definitions

### DIFF
--- a/include/vulkan/vk_sdk_platform.h
+++ b/include/vulkan/vk_sdk_platform.h
@@ -23,7 +23,9 @@
 #define VK_SDK_PLATFORM_H
 
 #if defined(_WIN32)
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #ifndef __cplusplus
 #undef inline
 #define inline __inline


### PR DESCRIPTION
`vk_platform_sdk.h` left this definition unguarded, potentially causing problems where this symbol is defined globally.