### PR TITLE
headers: Simplify Non-Dispatchable Handles

### DIFF
--- a/include/vulkan/vulkan_core.h
+++ b/include/vulkan/vulkan_core.h
@@ -54,15 +54,7 @@ extern "C" {
 
 
 #define VK_DEFINE_HANDLE(object) typedef struct object##_T* object;
-
-
-#if !defined(VK_DEFINE_NON_DISPATCHABLE_HANDLE)
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *object;
-#else
-        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef uint64_t object;
-#endif
-#endif
+#define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object { uint64_t opaqueHandle; } object;
 
 typedef uint32_t VkFlags;
 typedef uint32_t VkBool32;


### PR DESCRIPTION
Making the ND handles a struct containing a 64-bit value should make the preprocessor branch/pointer defintion unnecessary and also allow the strong typedef to exist on 32-bit platforms.

Related: https://stackoverflow.com/questions/51743500/why-do-non-dispatchable-handles-use-a-ptr-on-64bit-platofrms