### PR TITLE
Minor spelling fixes.

### DIFF
--- a/registry/vk.xml
+++ b/registry/vk.xml
@@ -5780,7 +5780,7 @@ typedef void <name>CAMetalLayer</name>;
     <enums name="VkBufferCreateFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_BUFFER_CREATE_SPARSE_BINDING_BIT"               comment="Buffer should support sparse backing"/>
         <enum bitpos="1"    name="VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT"             comment="Buffer should support sparse backing with partial residency"/>
-        <enum bitpos="2"    name="VK_BUFFER_CREATE_SPARSE_ALIASED_BIT"               comment="Buffer should support constent data access to physical memory ranges mapped into multiple locations of sparse buffers"/>
+        <enum bitpos="2"    name="VK_BUFFER_CREATE_SPARSE_ALIASED_BIT"               comment="Buffer should support constant data access to physical memory ranges mapped into multiple locations of sparse buffers"/>
     </enums>
     <enums name="VkShaderStageFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_SHADER_STAGE_VERTEX_BIT"/>
@@ -5805,7 +5805,7 @@ typedef void <name>CAMetalLayer</name>;
     <enums name="VkImageCreateFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_IMAGE_CREATE_SPARSE_BINDING_BIT"                comment="Image should support sparse backing"/>
         <enum bitpos="1"    name="VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT"              comment="Image should support sparse backing with partial residency"/>
-        <enum bitpos="2"    name="VK_IMAGE_CREATE_SPARSE_ALIASED_BIT"                comment="Image should support constent data access to physical memory ranges mapped into multiple locations of sparse images"/>
+        <enum bitpos="2"    name="VK_IMAGE_CREATE_SPARSE_ALIASED_BIT"                comment="Image should support constant data access to physical memory ranges mapped into multiple locations of sparse images"/>
         <enum bitpos="3"    name="VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT"                comment="Allows image views to have different format than the base image"/>
         <enum bitpos="4"    name="VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT"               comment="Allows creating image views with cube type from the created image"/>
     </enums>


### PR DESCRIPTION
constent -> constant (in 2 comments)