### PR TITLE
Add support for QNX Screen platform to ICD header.

### DIFF
--- a/include/vulkan/vk_icd.h
+++ b/include/vulkan/vk_icd.h
@@ -122,6 +122,7 @@ typedef enum {
     VK_ICD_WSI_PLATFORM_DIRECTFB,
     VK_ICD_WSI_PLATFORM_VI,
     VK_ICD_WSI_PLATFORM_GGP,
+    VK_ICD_WSI_PLATFORM_SCREEN,
 } VkIcdWsiPlatform;
 
 typedef struct {
@@ -232,5 +233,13 @@ typedef struct {
     void *window;
 } VkIcdSurfaceVi;
 #endif // VK_USE_PLATFORM_VI_NN
+
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+typedef struct {
+    VkIcdSurfaceBase base;
+    struct _screen_context *context;
+    struct _screen_window *window;
+} VkIcdSurfaceScreen;
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
 
 #endif  // VKICD_H


### PR DESCRIPTION
Hi,

This PR adds support for QNX Screen platform to the ICD header.

Not sure about patch for the genvk.py script, according to docs Vulkan-Docs should have the reference one, but it appears that this repository has more recent and updated genvk.py script. Same patch was already merged into the Vulkan-Docs.

Thanks!
