### PR TITLE
include: Add dllexport attribute while building vulkan DLLs.

### DIFF
--- a/include/vulkan/vk_layer.h
+++ b/include/vulkan/vk_layer.h
@@ -27,7 +27,13 @@
 #pragma once
 
 #include "vulkan.h"
-#if defined(__GNUC__) && __GNUC__ >= 4
+#if defined(_WIN32)
+#  if defined (VK_BUILDING_DLL)
+#    define VK_LAYER_EXPORT __declspec(dllexport)
+#  else
+#    define VK_LAYER_EXPORT
+#  endif
+#elif defined(__GNUC__) && __GNUC__ >= 4
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
This introduces a `VK_BUILDING_DLL` manifest constant. If this is correct the check has to be copied to all vulkan projects e.g. loader, validation layers etc.