### PR TITLE
Bump header version to 188 to match spec update

### DIFF
--- a/include/vulkan/vulkan.hpp
+++ b/include/vulkan/vulkan.hpp
@@ -115,7 +115,7 @@ extern "C" __declspec( dllimport ) FARPROC __stdcall GetProcAddress( HINSTANCE h
 #  include <span>
 #endif
 
-static_assert( VK_HEADER_VERSION == 187, "Wrong VK_HEADER_VERSION!" );
+static_assert( VK_HEADER_VERSION == 188, "Wrong VK_HEADER_VERSION!" );
 
 // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
 // To enable this feature on 32-bit platforms please define VULKAN_HPP_TYPESAFE_CONVERSION

--- a/include/vulkan/vulkan_core.h
+++ b/include/vulkan/vulkan_core.h
@@ -72,7 +72,7 @@ extern "C" {
 #define VK_API_VERSION_1_0 VK_MAKE_API_VERSION(0, 1, 0, 0)// Patch version should always be set to 0
 
 // Version of this file
-#define VK_HEADER_VERSION 187
+#define VK_HEADER_VERSION 188
 
 // Complete version of this file
 #define VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION(0, 1, 2, VK_HEADER_VERSION)

--- a/registry/vk.xml
+++ b/registry/vk.xml
@@ -155,7 +155,7 @@ branch of the member gitlab server.
         <type category="define" requires="VK_MAKE_API_VERSION">// Vulkan 1.2 version number
 #define <name>VK_API_VERSION_1_2</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 2, 0)// Patch version should always be set to 0</type>
         <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 187</type>
+#define <name>VK_HEADER_VERSION</name> 188</type>
         <type category="define" requires="VK_HEADER_VERSION">// Complete version of this file
 #define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 2, VK_HEADER_VERSION)</type>
 


### PR DESCRIPTION
@KarenGhavam-lunarG someone pointed out in https://github.com/KhronosGroup/Vulkan-Docs/issues/1603 that I'd not updated the spec version number to 188 in vk.xml. I've already made this change in the Vulkan-Docs tree and updated the v1.2.188 tag there, but I'm not sure what impact it would have to your work to commit this change in the Headers repo, so am assigning this to you to decide.

If you accept the PR, then the v1.2.188 tag (https://github.com/KhronosGroup/Vulkan-Headers/releases/tag/v1.2.188) will need to be deleted and re-created to point to the commit resulting from accepting the PR.