### PR TITLE
Update issue reference for non-API headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Files in this repository originate from:
 * README.md
 * cmake/Copyright_cmake.txt
 * cmake/cmake_uninstall.cmake.in
-* Non-API headers (report issues against @lenny-lunarg)
+* Non-API headers (report issues to the [Vulkan-Loader/issues](https://github.com/KhronosGroup/Vulkan-Loader/issues) tracker)
   * include/vulkan/vk_icd.h
   * include/vulkan/vk_layer.h
   * include/vulkan/vk_sdk_platform.h


### PR DESCRIPTION
The old description referred to a person who no longer is responsible for those files. 
I prefer to update the link to refer to the Vulkan-Loader so future changes in ownership
don't require updating this repo.