### PR TITLE
GN: Wayland include directories

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -27,8 +27,8 @@ config("vulkan_headers_config") {
   }
   if (defined(vulkan_use_wayland) && vulkan_use_wayland) {
     defines += [ "VK_USE_PLATFORM_WAYLAND_KHR" ]
-    if (defined(vulkan_wayland_include_dir)) {
-      include_dirs += [ "$vulkan_wayland_include_dir" ]
+    if (defined(vulkan_wayland_include_dirs)) {
+      include_dirs += vulkan_wayland_include_dirs
     }
   }
   if (is_android) {


### PR DESCRIPTION
Wayland headers can be found in multiple directories.
Here we use the array `vulkan_wayland_include_dirs` to specify those include directories.

This is an improvement of https://github.com/KhronosGroup/Vulkan-Headers/pull/267.
Also related to [this chromium CL](https://chromium-review.googlesource.com/c/chromium/src/+/3455146/comments/c1dba934_3a7f5e43).
@null77 @mikes-lunarg