### PR TITLE
Fix build for downstream VulkanSC uses

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -10,6 +10,7 @@ Instructions for building this repository on Windows, Linux, and MacOS.
 1. [Windows Build](#building-on-windows)
 1. [Linux Build](#building-on-linux)
 1. [MacOS Build](#building-on-macos)
+1. [Vulkan SC Build](#building-vulkan-sc)
 
 ## Contributing to the Repository
 
@@ -271,4 +272,17 @@ or
 
 The instructions for building this repository on MacOS are similar to those for Linux.
 
-[CMake 3.10.2](https://cmake.org/files/v3.10/cmake-3.10.2-Darwin-x86_64.tar.gz) is recommended.
+[CMake 3.10.2](https://cmake.org/files/v3.10/cmake-3.10.2-darwin-x86_64.tar.gz) is recommended.
+
+## Building Vulkan SC
+
+To build Vulkan SC instead of Vulkan (required for `sc_main` and derived branches)
+set the `VulkanSC` CMake variable to `TRUE`.
+
+For example:
+
+    cd Vulkan-Headers
+    mkdir build
+    cd build
+    cmake -DCMAKE_INSTALL_PREFIX=install -DVulkanSC=TRUE ..
+    make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,16 @@ cmake_minimum_required(VERSION 3.10.2)
 # NONE = this project has no language toolchain requirement.
 project(Vulkan-Headers NONE)
 
+
+# Add support for VulkanSC mode from the command line
+set(VulkanSC FALSE CACHE BOOL "User defined variable for VulkanSC mode to be passed in through cmake command line e.g. -DVulkanSC=TRUE")
+# Add preprocessor definition for VulkanSC.
+# This "VulkanSC" definition can be used to deactivate code that is not required for the VulkanSC builds.
+if(VulkanSC)
+add_definitions(-DVULKANSC)
+endif()
+
+
 # User-interface declarations ----------------------------------------------------------------------------------------------------
 # This section contains variables that affect development GUIs (e.g. CMake GUI and IDEs), such as option(), folders, and variables
 # with the CACHE property.
@@ -46,7 +56,9 @@ target_include_directories(Vulkan-Registry INTERFACE "${CMAKE_CURRENT_SOURCE_DIR
 add_library(Vulkan::Registry ALIAS Vulkan-Registry)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(NOT VulkanSC)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${CMAKE_INSTALL_DATADIR}/vulkan)
 
 # uninstall target

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ generated `.json` files in the `json/` directory.
 The contents of this repository are largely obtained from other repositories
 and are collected, coordinated, and curated here.
 
-If proposking changes to any file originating from a different repository,
+If proposing changes to any file originating from a different repository,
 please propose such changes in that repository, rather than Vulkan-Headers.
 Files in this repository originate from:
 

--- a/include/vulkan/vk_icd.h
+++ b/include/vulkan/vk_icd.h
@@ -23,7 +23,12 @@
 #ifndef VKICD_H
 #define VKICD_H
 
+#if defined(VULKANSC)
+#include "vulkan_sc.h"
+#else
 #include "vulkan.h"
+#endif
+
 #include <stdbool.h>
 
 // Loader-ICD version negotiation API.  Versions add the following features:

--- a/include/vulkan/vk_layer.h
+++ b/include/vulkan/vk_layer.h
@@ -26,7 +26,12 @@
  */
 #pragma once
 
+#if defined(VULKANSC)
+#include "vulkan_sc.h"
+#else
 #include "vulkan.h"
+#endif
+
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)


### PR DESCRIPTION
- video headers don't exist on this branch (and are not supported for Vulkan SC)
- loader interface files need to use vulkansc include instead of vulkan
- update documentation