### PR TITLE
Adding cmake target export and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,16 @@ endif()
 
 # define exported targets for nested project builds to consume
 add_library(Vulkan-Headers INTERFACE)
-target_include_directories(Vulkan-Headers INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(Vulkan-Headers INTERFACE $<BUILD_INTERFACE:"${CMAKE_CURRENT_SOURCE_DIR}/include">$<INSTALL_INTERFACE:include>)
 add_library(Vulkan::Headers ALIAS Vulkan-Headers)
 
 add_library(Vulkan-Registry INTERFACE)
-target_include_directories(Vulkan-Registry INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/registry")
+target_include_directories(Vulkan-Registry INTERFACE $<BUILD_INTERFACE:"${CMAKE_CURRENT_SOURCE_DIR}/registry">$<INSTALL_INTERFACE:include>)
 add_library(Vulkan::Registry ALIAS Vulkan-Registry)
+
+# Export and install targets so they can be consumed by other cmake projects
+install(TARGETS Vulkan-Headers Vulkan-Registry EXPORT VulkanHeadersConfig)
+install(EXPORT VulkanHeadersConfig DESTINATION share/VulkanHeaders)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
I saw that this CMake project had no target export & install setup so I figured I could add it quickly here. 

Allows build systems like [vcpkg](https://github.com/microsoft/vcpkg) to more easily consume the cmake build. I tested this by locally applying this patch to the vcpkg port of the vulkan headers and then consuming the target in another project. 

Downstream projects can consume an installed version of the library by locating and linking with just
```
find_package(VulkanHeaders CONFIG REQUIRED)
target_link_libraries(main PRIVATE Vulkan-Headers Vulkan-Registry)
```