### PR TITLE
GN: Wayland deps

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -58,5 +58,10 @@ source_set("vulkan_headers") {
     "include/vulkan/vulkan_screen.h",
   ]
   public_configs = [ ":vulkan_headers_config" ]
-}
 
+  deps = []
+  if (defined(vulkan_use_wayland) && vulkan_use_wayland &&
+      defined(vulkan_wayland_deps)) {
+    deps += vulkan_wayland_deps
+  }
+}


### PR DESCRIPTION
Some clients (Chromium in particular) build and link with own copy of libwayland providing different components with pregenerated wayland client headers. However, we are changing to automatically generated headers, which require components to depend on wayland_client gn target so that the headers are generated in time (otherwise, targets such as vulkan_headers, which include wayland-client-protocol.h header MAY fail to find that).

Thus, make vulkan_headers add an explicit dep if it's provided via build_overrides/vulkan_headers.