### PR TITLE
build: Fix CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,7 @@
 
 cmake_minimum_required(VERSION 3.10.2)
 
-# NONE = this project has no language toolchain requirement.
-project(Vulkan-Headers NONE)
+project(Vulkan-Headers LANGUAGES C)
 
 # User-interface declarations ----------------------------------------------------------------------------------------------------
 # This section contains variables that affect development GUIs (e.g. CMake GUI and IDEs), such as option(), folders, and variables


### PR DESCRIPTION
Currently GNUInstallDirs is complaining because no language has been enabled. This is fixed by enabling the C language.

Here is the full error:
```
CMake Warning (dev) at /home/juan/projects/dk/cmake/share/cmake-3.24/Modules/GNUInstallDirs.cmake:243 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  CMakeLists.txt:29 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```