### PR TITLE
cmake: Export CMake Targets File

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -39,11 +39,25 @@ indicated by *install_dir*:
 
 - *install_dir*`/include/vulkan` : The header files found in the
  `include/vulkan` directory of this repository
+- *install_dir*`/share/cmake/VulkanHeaders`: The CMake config files needed
+  for find_package support
 - *install_dir*`/share/vulkan/registry` : The registry files found in the
   `registry` directory of this repository
 
 The `uninstall` target can be used to remove the above files from the install
 directory.
+
+### Usage in CMake
+
+The library provides a Config file for CMake, once installed it can be found via `find_package`.
+
+Which, when successful, will add library target called `Vulkan::Headers` which you can use via the usual `target_link_libraries` mechanism.
+
+```cmake
+find_package(VulkanHeaders REQUIRED CONFIG)
+
+target_link_libraries(foobar PRIVATE Vulkan::Headers)
+```
 
 ## Repository Set-Up
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,47 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
-
-# CMake project initialization ---------------------------------------------------------------------------------------------------
-# This section contains pre-project() initialization, and ends with the project() command.
-
 cmake_minimum_required(VERSION 3.10.2)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake)
 
 project(Vulkan-Headers LANGUAGES C VERSION ${VK_VERSION_STRING})
 message(STATUS "${PROJECT_NAME} = ${PROJECT_VERSION}")
 
-# User-interface declarations ----------------------------------------------------------------------------------------------------
-# This section contains variables that affect development GUIs (e.g. CMake GUI and IDEs), such as option(), folders, and variables
-# with the CACHE property.
-
-include(GNUInstallDirs)
-
-if(WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    # Windows: if install locations not set by user, set install prefix to "<build_dir>\install".
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
-endif()
-
-# --------------------------------------------------------------------------------------------------------------------------------
-
-# define exported targets for nested project builds to consume
 add_library(Vulkan-Headers INTERFACE)
-target_include_directories(Vulkan-Headers INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(Vulkan-Headers INTERFACE $<BUILD_INTERFACE:"${CMAKE_CURRENT_SOURCE_DIR}/include">)
 add_library(Vulkan::Headers ALIAS Vulkan-Headers)
 
 add_library(Vulkan-Registry INTERFACE)
-target_include_directories(Vulkan-Registry INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/registry")
+target_include_directories(Vulkan-Registry INTERFACE $<BUILD_INTERFACE:"${CMAKE_CURRENT_SOURCE_DIR}/registry">)
 add_library(Vulkan::Registry ALIAS Vulkan-Registry)
 
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${CMAKE_INSTALL_DATADIR}/vulkan)
-
-# uninstall target
-if(NOT TARGET uninstall)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-                   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-                   IMMEDIATE
-                   @ONLY)
-    add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-endif()
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/install.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,4 +28,11 @@ add_library(Vulkan-Registry INTERFACE)
 target_include_directories(Vulkan-Registry INTERFACE $<BUILD_INTERFACE:"${CMAKE_CURRENT_SOURCE_DIR}/registry">)
 add_library(Vulkan::Registry ALIAS Vulkan-Registry)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/install.cmake)
+# https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
+string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
+
+option(VULKAN_HEADERS_INSTALL "Install Vulkan Headers" ${PROJECT_IS_TOP_LEVEL})
+
+if (VULKAN_HEADERS_INSTALL)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/install.cmake)
+endif()

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,0 +1,54 @@
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+if(WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    # Windows: if install locations not set by user, set install prefix to "<build_dir>\install".
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
+endif()
+
+# uninstall target
+if(NOT TARGET uninstall)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+                   IMMEDIATE
+                   @ONLY)
+    add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()
+
+# Location registry files will be installed to
+set(VLK_REGISTRY_DIR "${CMAKE_INSTALL_DATADIR}/vulkan")
+
+# Install header files
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# Install registry files
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${VLK_REGISTRY_DIR})
+
+set(export_name "VulkanHeadersConfig")
+set(namespace "Vulkan::")
+set(cmake_files_install_dir ${CMAKE_INSTALL_DATADIR}/cmake/VulkanHeaders/)
+
+# Set EXPORT_NAME for consistency with established names. The CMake generated ones won't work.
+set_target_properties(Vulkan-Headers PROPERTIES EXPORT_NAME "Headers")
+set_target_properties(Vulkan-Registry PROPERTIES EXPORT_NAME "Registry")
+
+# Add find_package() support
+target_include_directories(Vulkan-Headers INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+install(TARGETS Vulkan-Headers EXPORT ${export_name})
+
+target_include_directories(Vulkan-Registry INTERFACE $<INSTALL_INTERFACE:${VLK_REGISTRY_DIR}/registry>)
+install(TARGETS Vulkan-Registry EXPORT ${export_name})
+
+install(EXPORT ${export_name} NAMESPACE ${namespace} DESTINATION ${cmake_files_install_dir})
+export(TARGETS Vulkan-Headers NAMESPACE ${namespace} FILE ${export_name}.cmake)
+
+set(config_version "${CMAKE_CURRENT_BINARY_DIR}/${export_name}Version.cmake")
+
+# Add find_package() versioning support
+if(${CMAKE_VERSION} VERSION_LESS "3.14.0")
+    write_basic_package_version_file(${config_version} COMPATIBILITY SameMajorVersion)
+else()
+    write_basic_package_version_file(${config_version} COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+endif()
+
+install(FILES ${config_version} DESTINATION ${cmake_files_install_dir})


### PR DESCRIPTION
Now as part of install 2 files are created:
- VulkanHeadersConfig.cmake
- VulkanHeadersConfigVersion.cmake

This allows usage of find_package

closes #157

Also closes https://github.com/KhronosGroup/Vulkan-Headers/pull/207