### PR TITLE
cmake: Fix environment for cross-compile installs

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -26,7 +26,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${VLK_REGIS
 
 set(export_name "VulkanHeadersConfig")
 set(namespace "Vulkan::")
-set(cmake_files_install_dir ${CMAKE_INSTALL_DATADIR}/cmake/VulkanHeaders/)
+set(cmake_files_install_dir ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanHeaders/)
 
 # Set EXPORT_NAME for consistency with established names. The CMake generated ones won't work.
 set_target_properties(Vulkan-Headers PROPERTIES EXPORT_NAME "Headers")


### PR DESCRIPTION
Currently the include directory is arch-dependent. However, the location where the *.cmake files are installed
is arch-independent. This difference causes an issue with cross compile environments.