### PR TITLE
vk_icd.h: Add ICD Version 7

### DIFF
--- a/include/vulkan/vk_icd.h
+++ b/include/vulkan/vk_icd.h
@@ -2,9 +2,9 @@
 // File: vk_icd.h
 //
 /*
- * Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (c) 2015-2016, 2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2016, 2022 Valve Corporation
+ * Copyright (c) 2015-2016, 2022 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,17 @@
 //               call for any API version > 1.0.  Otherwise, the loader will
 //               manually determine if it can support the expected version.
 //   Version 6 - Add support for vk_icdEnumerateAdapterPhysicalDevices.
-#define CURRENT_LOADER_ICD_INTERFACE_VERSION 6
+//   Version 7 - If an ICD supports any of the following functions, they must be
+//               queryable with vk_icdGetInstanceProcAddr:
+//                   vk_icdNegotiateLoaderICDInterfaceVersion
+//                   vk_icdGetPhysicalDeviceProcAddr
+//                   vk_icdEnumerateAdapterPhysicalDevices (Windows only)
+//               In addition, these functions no longer need to be exported directly.
+//               This version allows drivers provided through the extension
+//               VK_LUNARG_direct_driver_loading be able to support the entire
+//               Driver-Loader interface.
+
+#define CURRENT_LOADER_ICD_INTERFACE_VERSION 7
 #define MIN_SUPPORTED_LOADER_ICD_INTERFACE_VERSION 0
 #define MIN_PHYS_DEV_EXTENSION_ICD_INTERFACE_VERSION 4
 


### PR DESCRIPTION
If an ICD supports any of the following functions, they must be queryable with vk_icdGetInstanceProcAddr:
    vk_icdNegotiateLoaderICDInterfaceVersion
    vk_icdGetPhysicalDeviceProcAddr
    vk_icdEnumerateAdapterPhysicalDevices (Windows only)
In addition, these functions no longer need to be exported directly.

These changes allow drivers to no longer export the 'loader-icd interface' functions which previously had to be exported. This change aids in future extension work which aims to provide the ability to load drivers without installing them to the system.