### PR TITLE
cmake: Install cmake files to CMAKE_INSTALL_DATADIR

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -26,7 +26,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${VLK_REGIS
 
 set(export_name "VulkanHeadersConfig")
 set(namespace "Vulkan::")
-set(cmake_files_install_dir ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanHeaders/)
+set(cmake_files_install_dir ${CMAKE_INSTALL_DATADIR}/cmake/VulkanHeaders/)
 
 # Set EXPORT_NAME for consistency with established names. The CMake generated ones won't work.
 set_target_properties(Vulkan-Headers PROPERTIES EXPORT_NAME "Headers")


### PR DESCRIPTION
If we install the cmake files into the default ABI directory, then multi-ABI builds using vulkan-headers don't work because they look for the ABI-specific cmake files which don't exist if current ABI is not the default ABI. I hit this trying to build vulkan-loader in -m32 on Gentoo, it failed now because vulkan-loader just started trying to look for the cmake files.

We need to install in the data directory.

Similar commit in spirv-headers: https://github.com/KhronosGroup/SPIRV-Headers/commit/eae955f0525724526fa602fd126623b9d84599fa


Signed-off-by: Nick Sarnie <sarnex@gentoo.org>