### PR TITLE
cmake: Fix cross-compilation

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -26,7 +26,7 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${VLK_REGIS
 
 set(export_name "VulkanHeadersConfig")
 set(namespace "Vulkan::")
-set(cmake_files_install_dir ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanHeaders/)
+set(cmake_files_install_dir ${CMAKE_INSTALL_DATADIR}/cmake/VulkanHeaders/)
 
 # Set EXPORT_NAME for consistency with established names. The CMake generated ones won't work.
 set_target_properties(Vulkan-Headers PROPERTIES EXPORT_NAME "Headers")


### PR DESCRIPTION
We need to revert b092b2f in Gentoo to fix multi-ABI vulkan-loader build

This reverts commit b092b2fccc812453c1d0ec0a829eb8f34f174803.

See https://github.com/KhronosGroup/Vulkan-Headers/issues/330 for details.