### PR TITLE
cmake: Preserve permissions from registry files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (PROJECT_IS_TOP_LEVEL)
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     # Install registry files
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${VLK_REGISTRY_DIR})
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${VLK_REGISTRY_DIR} USE_SOURCE_PERMISSIONS)
 
     set(export_name "VulkanHeadersConfig")
     set(namespace "Vulkan::")


### PR DESCRIPTION
Partially addresses https://github.com/KhronosGroup/Vulkan-Headers/issues/336

Permissions are now preserved for genvk.py