### PR TITLE
cmake: Avoid parsing version during configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,37 +16,7 @@
 # ~~~
 cmake_minimum_required(VERSION 3.10.2)
 
-# Written as a function to minimize variable scope
-# Only VK_VERSION_STRING will be returned to the PARENT_SCOPE
-function(vlk_get_header_version)
-    set(vulkan_core_header_file "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan/vulkan_core.h")
-    if (NOT EXISTS ${vulkan_core_header_file})
-        message(FATAL_ERROR "Couldn't find vulkan_core.h!")
-    endif()
-
-    file(READ ${vulkan_core_header_file} ver)
-
-    # Get the major/minor version
-    if (ver MATCHES "#define[ ]+VK_HEADER_VERSION_COMPLETE[ ]+VK_MAKE_API_VERSION\\([ ]*[0-9]+,[ ]*([0-9]+),[ ]*([0-9]+),[ ]*VK_HEADER_VERSION[ ]*\\)")
-        set(VK_VERSION_MAJOR "${CMAKE_MATCH_1}")
-        set(VK_VERSION_MINOR "${CMAKE_MATCH_2}")
-    else()
-        message(FATAL_ERROR "Couldn't get major/minor version")
-    endif()
-
-    # Get the patch version
-    if (ver MATCHES "#define[ ]+VK_HEADER_VERSION[ ]+([0-9]+)")
-        set(VK_HEADER_VERSION "${CMAKE_MATCH_1}")
-    else()
-        message(FATAL_ERROR "Couldn't get the patch version")
-    endif()
-
-    set(VK_VERSION_STRING "${VK_VERSION_MAJOR}.${VK_VERSION_MINOR}.${VK_HEADER_VERSION}" PARENT_SCOPE)
-endfunction()
-vlk_get_header_version()
-
-project(Vulkan-Headers LANGUAGES C VERSION ${VK_VERSION_STRING})
-message(STATUS "${PROJECT_NAME} = ${PROJECT_VERSION}")
+project(Vulkan-Headers LANGUAGES C VERSION 1.3.238)
 
 add_library(Vulkan-Headers INTERFACE)
 target_include_directories(Vulkan-Headers INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,34 @@
 # limitations under the License.
 # ~~~
 
+set(vulkan_core_header_file "${PROJECT_SOURCE_DIR}/include/vulkan/vulkan_core.h")
+if (NOT EXISTS ${vulkan_core_header_file})
+    message(FATAL_ERROR "Couldn't find vulkan_core.h!")
+endif()
+
+file(READ ${vulkan_core_header_file} ver)
+
+# Get the major/minor version
+if (ver MATCHES "#define[ ]+VK_HEADER_VERSION_COMPLETE[ ]+VK_MAKE_API_VERSION\\([ ]*[0-9]+,[ ]*([0-9]+),[ ]*([0-9]+),[ ]*VK_HEADER_VERSION[ ]*\\)")
+    set(VK_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(VK_VERSION_MINOR "${CMAKE_MATCH_2}")
+else()
+    message(FATAL_ERROR "Couldn't get major/minor version")
+endif()
+
+# Get the patch version
+if (ver MATCHES "#define[ ]+VK_HEADER_VERSION[ ]+([0-9]+)")
+    set(VK_HEADER_VERSION "${CMAKE_MATCH_1}")
+else()
+    message(FATAL_ERROR "Couldn't get the patch version")
+endif()
+
+set(VK_VERSION_STRING "${VK_VERSION_MAJOR}.${VK_VERSION_MINOR}.${VK_HEADER_VERSION}")
+
+if (NOT ${VK_VERSION_STRING} STREQUAL ${PROJECT_VERSION})
+    message(FATAL_ERROR "Project version is ${PROJECT_VERSION} but should be ${VK_VERSION_STRING}!")
+endif()
+
 # Test the non-API headers provided by this repo
 # NOTE: For us testing just means that these header files compile
 # with reasonable warnings.


### PR DESCRIPTION
During future Vulkan Header updates the version will need to updated in CMakeLists.txt

The intent is to reduce complexity in the primary CMakeLists.txt and slightly increase build performance.

Many people look at the Vulkan CMake code as reference. So it's better for the community to have a clean example.