### PR TITLE
Add new vulkan_headers files to BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -56,6 +56,10 @@ source_set("vulkan_headers") {
     "include/vulkan/vulkan.hpp",
     "include/vulkan/vulkan_core.h",
     "include/vulkan/vulkan_screen.h",
+    "include/vk_video/vulkan_video_codec_h264std.h",
+    "include/vk_video/vulkan_video_codec_h264std_decode.h",
+    "include/vk_video/vulkan_video_codec_h265std.h",
+    "include/vk_video/vulkan_video_codec_h265std_decode.h",
   ]
   public_configs = [ ":vulkan_headers_config" ]
 }


### PR DESCRIPTION
The commit https://github.com/KhronosGroup/Vulkan-Headers/commit/00671c64ba5c488ade22ad572a0ef81d5e64c803 has included new header files under include/vk_videos in vulkan_core.h.

ANGLE's presubmit script export_targets.py: https://github.com/google/angle/blob/main/scripts/export_targets.py is complaining about "Included file must be listed in the GN target or its public dependency."

Add the new header files to BUILD.gn to resolve the script error.