### PR TITLE
headers: Remove VK_LAYER_EXPORT

### DIFF
--- a/include/vulkan/vk_layer.h
+++ b/include/vulkan/vk_layer.h
@@ -28,14 +28,6 @@
 
 #include "vulkan_core.h"
 
-#if defined(__GNUC__) && __GNUC__ >= 4
-#define VK_LAYER_EXPORT __attribute__((visibility("default")))
-#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590)
-#define VK_LAYER_EXPORT __attribute__((visibility("default")))
-#else
-#define VK_LAYER_EXPORT
-#endif
-
 #define MAX_NUM_UNKNOWN_EXTS 250
 
  // Loader-Layer version negotiation API.  Versions add the following features:

--- a/tests/vk_layer.c
+++ b/tests/vk_layer.c
@@ -1,7 +1,6 @@
 #include "vulkan/vk_layer.h"
 
-// Use helper macro intended for vulkan layers to export functions
-VK_LAYER_EXPORT int foobar()
+int foobar()
 {
     return 0;
 }


### PR DESCRIPTION
- It hasn't been handling windows (so it's been half implemented)
- It's a suboptimal method for exporting symbols for vulkan layers since `--version-script` and `.def` files exists. Both of these methods also don't risk name mangling.
- `--version-script` also has perf benefits since you can silence exports from code you didn't intend to export