### PR TITLE
Add -Wno-redundant-parens to BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -43,6 +43,11 @@ config("vulkan_headers_config") {
   if (defined(is_ggp) && is_ggp) {
     defines += [ "VK_USE_PLATFORM_GGP" ]
   }
+  if (is_clang) {
+    cflags = [
+      "-Wno-redundant-parens",
+    ]
+  }
 }
 
 # Vulkan headers only, no compiled sources.


### PR DESCRIPTION
The SC vk.xml merge added extra parentheses to the VK_DEFINE_NON_DISPATCHABLE_HANDLES macro in order to satisfy MISRA rule 20.7.  Make sure this doesn't break downstream builds that would otherwise warn about them.
