### PR TITLE
cmake: Update min to 3.15

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: 3.15.0
+          cmakeVersion: 3.17.0
       - name: Configure Vulkan-Headers
         run: cmake -S . -B build -G "Ninja"
       - name: Install Vulkan-Headers
@@ -53,6 +53,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: 3.14.0
+          cmakeVersion: 3.15.0
       - name: Configure Vulkan-Headers
-        run: cmake -S . -B build/ -G "Ninja"
+        run: cmake -S . -B build/ -G "Ninja" --loglevel=DEBUG
+      - name: Install Vulkan-Headers
+        run: cmake --install build/ --prefix build/install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
-cmake_minimum_required(VERSION 3.14...3.25)
+cmake_minimum_required(VERSION 3.15...3.25)
 
 function(vlk_get_header_version)
     set(vulkan_core_header_file "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan/vulkan_core.h")
@@ -43,9 +43,7 @@ vlk_get_header_version()
 
 project(Vulkan-Headers LANGUAGES C VERSION ${VK_VERSION_STRING})
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
-    message(DEBUG "${PROJECT_NAME} = ${PROJECT_VERSION}")
-endif()
+message(DEBUG "${PROJECT_NAME} = ${PROJECT_VERSION}")
 
 add_library(Vulkan-Headers INTERFACE)
 target_include_directories(Vulkan-Headers INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)


### PR DESCRIPTION
- Removes conditional 3.15 logic
- Guarantees usage of --install/--loglevel for CI/package managers