### PR TITLE
Allow finding Python in other locations

### DIFF
--- a/registry/apiconventions.py
+++ b/registry/apiconventions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2021-2023 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0

--- a/registry/cgenerator.py
+++ b/registry/cgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/registry/generator.py
+++ b/registry/generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/registry/genvk.py
+++ b/registry/genvk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/registry/parse_dependency.py
+++ b/registry/parse_dependency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright 2022-2023 The Khronos Group Inc.
 # Copyright 2003-2019 Paul McGuire

--- a/registry/reg.py
+++ b/registry/reg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/registry/spec_tools/conventions.py
+++ b/registry/spec_tools/conventions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #

--- a/registry/stripAPI.py
+++ b/registry/stripAPI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2023 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0

--- a/registry/vkconventions.py
+++ b/registry/vkconventions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 #
 # Copyright 2013-2023 The Khronos Group Inc.
 #


### PR DESCRIPTION
Although a lot of Linux OS's provide Python in /usr/bin that is not always the case and outside of Linux that is not the case.