### PR TITLE
Update for Vulkan-Docs 1.3.248

### DIFF
--- a/registry/generator.py
+++ b/registry/generator.py
@@ -153,6 +153,7 @@ class GeneratorOptions:
                  directory='.',
                  genpath=None,
                  apiname=None,
+                 mergeApiNames=None,
                  profile=None,
                  versions='.*',
                  emitversions='.*',
@@ -176,6 +177,8 @@ class GeneratorOptions:
         - directory - directory in which to generate filename
         - genpath - path to previously generated files, such as apimap.py
         - apiname - string matching `<api>` 'apiname' attribute, e.g. 'gl'.
+        - mergeApiNames - If not None, a comma separated list of API names
+          to merge into the API specified by 'apiname'
         - profile - string specifying API profile , e.g. 'core', or None.
         - versions - regex matching API versions to process interfaces for.
         Normally `'.*'` or `'[0-9][.][0-9]'` to match all defined versions.
@@ -228,6 +231,9 @@ class GeneratorOptions:
 
         self.apiname = apiname
         "string matching `<api>` 'apiname' attribute, e.g. 'gl'."
+
+        self.mergeApiNames = mergeApiNames
+        "comma separated list of API names to merge into the API specified by 'apiname'"
 
         self.profile = profile
         "string specifying API profile , e.g. 'core', or None."

--- a/registry/genvk.py
+++ b/registry/genvk.py
@@ -148,6 +148,9 @@ def makeGenOpts(args):
     else:
         defaultAPIName = conventions.xml_api_name
 
+    # APIs to merge
+    mergeApiNames = args.mergeApiNames
+
     # API include files for spec and ref pages
     # Overwrites include subdirectories in spec source tree
     # The generated include files do not include the calling convention
@@ -442,6 +445,7 @@ def makeGenOpts(args):
             directory         = directory,
             genpath           = None,
             apiname           = defaultAPIName,
+            mergeApiNames     = mergeApiNames,
             profile           = None,
             versions          = featuresPat,
             emitversions      = None,
@@ -483,6 +487,7 @@ def makeGenOpts(args):
             directory         = directory,
             genpath           = None,
             apiname           = defaultAPIName,
+            mergeApiNames     = mergeApiNames,
             profile           = None,
             versions          = featuresPat,
             emitversions      = featuresPat,
@@ -599,10 +604,11 @@ def makeGenOpts(args):
             directory         = directory,
             genpath           = None,
             apiname           = defaultAPIName,
+            mergeApiNames     = mergeApiNames,
             profile           = None,
             versions          = None,
             emitversions      = None,
-            defaultExtensions = None,
+            defaultExtensions = defaultAPIName,
             addExtensions     = addExtensionRE,
             removeExtensions  = None,
             emitExtensions    = emitExtensionRE,
@@ -727,6 +733,9 @@ if __name__ == '__main__':
     parser.add_argument('-apiname', action='store',
                         default=None,
                         help='Specify API to generate (defaults to repository-specific conventions object value)')
+    parser.add_argument('-mergeApiNames', action='store',
+                        default=None,
+                        help='Specify a comma separated list of APIs to merge into the target API')
     parser.add_argument('-defaultExtensions', action='store',
                         default=APIConventions().xml_api_name,
                         help='Specify a single class of extensions to add to targets')

--- a/registry/vk.xml
+++ b/registry/vk.xml
@@ -173,7 +173,7 @@ branch of the member gitlab server.
 #define <name>VKSC_API_VERSION_1_0</name> <type>VK_MAKE_API_VERSION</type>(VKSC_API_VARIANT, 1, 0, 0)// Patch version should always be set to 0</type>
 
         <type api="vulkan" category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 247</type>
+#define <name>VK_HEADER_VERSION</name> 248</type>
         <type api="vulkan" category="define" requires="VK_HEADER_VERSION">// Complete version of this file
 #define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 3, VK_HEADER_VERSION)</type>
         <type api="vulkansc" category="define">// Version of this file


### PR DESCRIPTION
<!-- Please note when contributing what files this repository actually is responsible for.

Vulkan-Headers exists as a publishing mechanism for headers and related material sourced from multiple other repositories. If you have a problem with that material, it should *not* be reported here, but in the appropriate repository:

This repository is responsible for the following files

* BUILD.gn
* BUILD.md
* cmake/
* CMakeLists.txt
* tests/*
* CODE_OF_CONDUCT.md
* INTEGRATION.md
* LICENSE.txt
* README.md
* Non-API headers
  * include/vulkan/vk_icd.h
  * include/vulkan/vk_layer.h

-->
