### PR TITLE
Set minimal permissions to github workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,6 +19,9 @@ on:
     pull_request:
         branches:
             - main
+            
+permissions:
+    contents: read
 
 jobs:
   ubuntu-cmake-install:


### PR DESCRIPTION
<!-- Please note when contributing what files this repository actually is responsible for.

Vulkan-Headers exists as a publishing mechanism for headers and related material sourced from multiple other repositories. If you have a problem with that material, it should *not* be reported here, but in the appropriate repository:

This repository is responsible for the following files

* BUILD.gn
* BUILD.md
* cmake/
* CMakeLists.txt
* tests/*
* CODE_OF_CONDUCT.md
* INTEGRATION.md
* LICENSE.txt
* README.md
* Non-API headers
  * include/vulkan/vk_icd.h
  * include/vulkan/vk_layer.h

-->

Closes #399 

## Changes

contents: read is enough for linux.yml to run, see https://github.com/joycebrum/Vulkan-Headers/actions/runs/4985111418