### PR TITLE
cmake: fix config file

### DIFF
--- a/cmake/VulkanHeadersConfig.cmake.in
+++ b/cmake/VulkanHeadersConfig.cmake.in
@@ -1,5 +1,7 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/VulkanHeadersTargets.cmake")
+if (NOT TARGET Vulkan::Headers)
+    include("${CMAKE_CURRENT_LIST_DIR}/VulkanHeadersTargets.cmake")
+endif()
 
 set(VULKAN_HEADERS_REGISTRY_DIRECTORY "@PACKAGE_VULKAN_HEADERS_REGISTRY_DIRECTORY@")


### PR DESCRIPTION
Allow `find_package` to find the headers directly from the build tree (in fact allow `find_package` to do nothing, and instead use the target already created by `add_subdirectory`):
```
set(VULKAN_HEADERS_INSTALL ON)
add_subdirectory(Vulkan-Headers)
set(VulkanHeaders_DIR "${CMAKE_CURRENT_BINARY_DIR}/Vulkan-Headers")
...
find_package(VulkanHeaders) # will find and use the headers in the above subdirectory
```
When using `add_subdirectory`, the target `Vulkan::Headers` is created but not the file `VulkanHeadersTargets.cmake`.

- https://github.com/libsdl-org/SDL/blob/00fc50557ec3852ecaa92af942d80a0c7d7f175e/cmake/SDL3Config.cmake.in#L15-L17
- https://github.com/gnuradio/volk/blob/4ed9334bac566a51022b4c1b9b952e7c5596151f/cmake/Modules/VolkConfig.cmake.in#L10-L12
- https://gitlab.matrix.org/matrix-org/olm/-/blob/master/cmake/OlmConfig.cmake.in#L7-9