### PR TITLE
cmake: Remove VULKAN_HEADERS_INSTALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,19 +57,14 @@ if (PROJECT_IS_TOP_LEVEL)
     if (BUILD_TESTS)
         add_subdirectory(tests)
     endif()
-endif()
 
-option(VULKAN_HEADERS_INSTALL "Install Vulkan Headers" ${PROJECT_IS_TOP_LEVEL})
-if (VULKAN_HEADERS_INSTALL)
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
-
-    set(VLK_REGISTRY_DIR "${CMAKE_INSTALL_DATADIR}/vulkan")
 
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     # Preserve source permissions https://github.com/KhronosGroup/Vulkan-Headers/issues/336
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION ${VLK_REGISTRY_DIR} USE_SOURCE_PERMISSIONS)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION "${CMAKE_INSTALL_DATADIR}/vulkan" USE_SOURCE_PERMISSIONS)
 
     set_target_properties(Vulkan-Headers PROPERTIES EXPORT_NAME "Headers")
 

--- a/tests/add_subdirectory/CMakeLists.txt
+++ b/tests/add_subdirectory/CMakeLists.txt
@@ -8,12 +8,9 @@ if (NOT TARGET Vulkan::Headers)
     message(FATAL_ERROR "Vulkan::Headers target not defined")
 endif()
 
-# By default installation for a subproject should be disabled.
-# This makes it easier to consume for most projects.
-# Consuming the vulkan-headers via add_subdirectory and installing
-# them is the more niche use case.
-if (VULKAN_HEADERS_INSTALL)
-    message(FATAL_ERROR "VULKAN_HEADERS_INSTALL should be OFF!")
+# Consuming vulkan-headers via add_subdirectory should NOT add installation code to the parent CMake project.
+if (DEFINED CMAKE_INSTALL_INCLUDEDIR)
+    message(FATAL_ERROR "CMAKE_INSTALL_INCLUDEDIR was defined!")
 endif()
 
 add_library(foobar STATIC)


### PR DESCRIPTION
VULKAN_HEADERS_INSTALL was added since it was believed there was a valid use case for it.

After looking into the use case that provoked this change there is no reason to keep VULKAN_HEADERS_INSTALL as an option.

Here is the use case we do NOT want to support:
https://github.com/KhronosGroup/Vulkan-Headers/pull/416#issuecomment-1622318949

Fundamentally this problem is caused add_subdirectory/find_package not being able to work together flawlessly.

Which isn't the responsibility of Vulkan-Headers to fix.

It's the responsibility of projects that consume Vulkan-Headers to account for either method.