### PR TITLE
ci: Fix -Wdeprecated-non-prototype warnings

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ if (MSVC)
 endif()
 
 # vk_icd.h
-add_executable(vk_icd vk_icd.c)
+add_library(vk_icd MODULE vk_icd.c)
 target_link_libraries(vk_icd PRIVATE Vulkan::Headers)
 
 # vk_layer.h

--- a/tests/vk_icd.c
+++ b/tests/vk_icd.c
@@ -8,7 +8,7 @@
 
 #include "vulkan/vk_icd.h"
 
-int main()
+int square(int i)
 {
-    return 0;
+    return i * i;
 }

--- a/tests/vk_layer.c
+++ b/tests/vk_layer.c
@@ -8,7 +8,7 @@
 
 #include "vulkan/vk_layer.h"
 
-int foobar()
+int square(int i)
 {
-    return 0;
+    return i * i;
 }


### PR DESCRIPTION
Occurs on AppleClang