### PR TITLE
ci: Fix fork development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ name: ci
 
 on:
   push:
-    branches:
-    - main
   pull_request:
     branches:
     - main


### PR DESCRIPTION
Well the prior change does eliminate duplicate runs it stops automated testing on forks.

<!-- Please note when contributing what files this repository actually is responsible for.

Vulkan-Headers exists as a publishing mechanism for headers and related material sourced from multiple other repositories. If you have a problem with that material, it should *not* be reported here, but in the appropriate repository:

This repository is responsible for the following files

* BUILD.gn
* BUILD.md
* CMakeLists.txt
* tests/*
* CODE_OF_CONDUCT.md
* INTEGRATION.md
* LICENSE.txt
* README.md
* Non-API headers
  * include/vulkan/vk_icd.h
  * include/vulkan/vk_layer.h

-->
