### PR TITLE
gn: Fix validation layer build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -27,8 +27,14 @@ config("vulkan_headers_config") {
   if (is_fuchsia) {
     defines += [ "VK_USE_PLATFORM_FUCHSIA" ]
   }
-  if (is_mac) {
+  if (is_apple) {
     defines += [ "VK_USE_PLATFORM_METAL_EXT" ]
+  }
+  if (is_mac) {
+    defines += [ "VK_USE_PLATFORM_MACOS_MVK" ]
+  }
+  if (is_ios) {
+    defines += [ "VK_USE_PLATFORM_IOS_MVK" ]
   }
   if (defined(is_ggp) && is_ggp) {
     defines += [ "VK_USE_PLATFORM_GGP" ]


### PR DESCRIPTION
closes KhronosGroup/Vulkan-ValidationLayers/issues/6780

<!-- Please note when contributing what files this repository actually is responsible for.

Vulkan-Headers exists as a publishing mechanism for headers and related material sourced from multiple other repositories. If you have a problem with that material, it should *not* be reported here, but in the appropriate repository:

This repository is responsible for the following files

* BUILD.gn
* BUILD.md
* CMakeLists.txt
* tests/*
* CODE_OF_CONDUCT.md
* LICENSE.txt
* README.md
* Non-API headers
  * include/vulkan/vk_icd.h
  * include/vulkan/vk_layer.h

-->
