### PR TITLE
Fix testing for 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
           cmakeVersion: ${{ matrix.cmake-version }} 
       - uses: ilammy/msvc-dev-cmd@v1
       - run: cmake -S . -B build -D BUILD_TESTS=ON -G Ninja
-      - run: ctest --test-dir build --output-on-failure
+      - run: ctest --output-on-failure
+        working-directory: build
 
   reuse:
     runs-on: ubuntu-latest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,17 +6,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # ~~~
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
-    set(fresh "--fresh")
-endif()
-
 # Test add_subdirectory suppport
 add_test(NAME integration.add_subdirectory
     COMMAND ${CMAKE_CTEST_COMMAND}
         --build-and-test ${CMAKE_CURRENT_LIST_DIR}/integration
                          ${CMAKE_CURRENT_BINARY_DIR}/add_subdirectory
         --build-generator ${CMAKE_GENERATOR}
-        --build-options -DFIND_PACKAGE_TESTING=OFF "${fresh}"
+        --build-options -DFIND_PACKAGE_TESTING=OFF
 )
 
 set(test_install_dir "${CMAKE_CURRENT_BINARY_DIR}/install")
@@ -30,7 +26,7 @@ add_test(NAME integration.find_package
         --build-and-test ${CMAKE_CURRENT_LIST_DIR}/integration
                          ${CMAKE_CURRENT_BINARY_DIR}/find_package
         --build-generator ${CMAKE_GENERATOR}
-        --build-options -DFIND_PACKAGE_TESTING=ON -DCMAKE_PREFIX_PATH=${test_install_dir} "${fresh}"
+        --build-options -DFIND_PACKAGE_TESTING=ON -DCMAKE_PREFIX_PATH=${test_install_dir}
 )
 
 # Installing comes before testing

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_test(NAME integration.add_subdirectory
 
 set(test_install_dir "${CMAKE_CURRENT_BINARY_DIR}/install")
 add_test(NAME integration.install
-    COMMAND ${CMAKE_COMMAND} --install ${VULKAN_HEADERS_BINARY_DIR} --prefix ${test_install_dir}
+    COMMAND ${CMAKE_COMMAND} --install ${VULKAN_HEADERS_BINARY_DIR} --prefix ${test_install_dir} --config $<CONFIG>
 )
 
 # Test find_package suppport


### PR DESCRIPTION
<!-- Please note when contributing what files this repository actually is responsible for.

Vulkan-Headers exists as a publishing mechanism for headers and related material sourced from multiple other repositories. If you have a problem with that material, it should *not* be reported here, but in the appropriate repository:

This repository is responsible for the following files

* BUILD.gn
* BUILD.md
* CMakeLists.txt
* tests/*
* CODE_OF_CONDUCT.md
* LICENSE.txt
* README.md
* Non-API headers
  * include/vulkan/vk_icd.h
  * include/vulkan/vk_layer.h

-->
