### PR TITLE
cmake: Allow external control of whether to test or install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CMAKE_GENERATOR: Ninja
-            
+
 permissions:
     contents: read
 
@@ -27,9 +27,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
         with:
-          cmakeVersion: ${{ matrix.cmake-version }} 
+          cmakeVersion: ${{ matrix.cmake-version }}
       - uses: ilammy/msvc-dev-cmd@v1
-      - run: cmake -S . -B build -D BUILD_TESTS=ON -G Ninja
+      - run: cmake -S . -B build -D VULKAN_HEADERS_ENABLE_TESTS=ON -D VULKAN_HEADERS_ENABLE_INSTALL=ON -G Ninja
       - run: ctest --output-on-failure
         working-directory: build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,15 @@ if (CMAKE_VERSION VERSION_LESS "3.21")
     string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
 endif()
 
-if (PROJECT_IS_TOP_LEVEL)
-    option(BUILD_TESTS "Build the tests")
-    if (BUILD_TESTS)
-        enable_testing()
-        add_subdirectory(tests)
-    endif()
+option(VULKAN_HEADERS_ENABLE_TESTS "Test Vulkan-Headers" ${PROJECT_IS_TOP_LEVEL})
+option(VULKAN_HEADERS_ENABLE_INSTALL "Install Vulkan-Headers" ${PROJECT_IS_TOP_LEVEL})
 
+if (VULKAN_HEADERS_ENABLE_TESTS)
+    enable_testing() # This is only effective in the top level CMakeLists.txt file.
+    add_subdirectory(tests)
+endif()
+
+if (VULKAN_HEADERS_ENABLE_INSTALL)
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
This makes the project more composable: It can be built and tested as part of a larger set of projects, from source.

