### PR TITLE
Add a new `IMPORTED` target `Vulkan::VulkanHppModule` which contains `vulkan.cppm`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
           cmakeVersion: ${{ matrix.cmake-version }}
       - uses: ilammy/msvc-dev-cmd@v1
       - run: cmake -S . -B build -D VULKAN_HEADERS_ENABLE_TESTS=ON -D VULKAN_HEADERS_ENABLE_INSTALL=ON -G Ninja
-      - run: cmake --install build/ --prefix build/install
-      - run: ctest --output-on-failure
+      - run: cmake --build ./build --verbose
+      - run: cmake --install build/ --prefix build/install --verbose
+      - run: ctest --output-on-failure --verbose
         working-directory: build
 
   reuse:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ permissions:
     contents: read
 
 jobs:
-  cmake:
+  cmake-unix:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         cmake-version: [ '3.15', 'latest']
     steps:
       - uses: actions/checkout@v4
@@ -30,9 +30,26 @@ jobs:
           cmakeVersion: ${{ matrix.cmake-version }}
       - uses: ilammy/msvc-dev-cmd@v1
       - run: cmake -S . -B build -D VULKAN_HEADERS_ENABLE_TESTS=ON -D VULKAN_HEADERS_ENABLE_INSTALL=ON -G Ninja
-      - run: cmake --build ./build --verbose
-      - run: cmake --install build/ --prefix build/install --verbose
-      - run: ctest --output-on-failure --verbose
+      - run: cmake --build ./build
+      - run: cmake --install build/ --prefix build/install
+      - run: ctest --output-on-failure
+        working-directory: build
+
+  cmake-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        cmake-version: [ '3.15', 'latest']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: ${{ matrix.cmake-version }}
+      - uses: ilammy/msvc-dev-cmd@v1
+      - run: cmake -S . -B build -D VULKAN_HEADERS_ENABLE_TESTS=ON -D VULKAN_HEADERS_ENABLE_INSTALL=ON -G Ninja -DVULKAN_HEADERS_ENABLE_MODULE=OFF # workaround for compiler bug in 17.10 and before
+      - run: cmake --build ./build
+      - run: cmake --install build/ --prefix build/install
+      - run: ctest --output-on-failure
         working-directory: build
 
   reuse:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           cmakeVersion: ${{ matrix.cmake-version }}
       - uses: ilammy/msvc-dev-cmd@v1
       - run: cmake -S . -B build -D VULKAN_HEADERS_ENABLE_TESTS=ON -D VULKAN_HEADERS_ENABLE_INSTALL=ON -G Ninja
+      - run: cmake --install build/ --prefix build/install
       - run: ctest --output-on-failure
         working-directory: build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,9 @@ if (MSVC AND (MSVC_VERSION GREATER_EQUAL "1934") OR
     set(COMPILER_SUPPORTS_CXX_MODULES TRUE)
 endif()
 
+option(VULKAN_HEADERS_ENABLE_MODULE "Enables building of the Vulkan C++ module. Default is true if supported by the CMake version and compilers" ${COMPILER_SUPPORTS_CXX_MODULES})
 
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND COMPILER_SUPPORTS_CXX_MODULES)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND VULKAN_HEADERS_ENABLE_MODULE)
     add_library(Vulkan-Module)
     add_library(Vulkan::VulkanHppModule ALIAS Vulkan-Module)
     target_sources(Vulkan-Module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ~~~
-cmake_minimum_required(VERSION 3.15...3.25)
+cmake_minimum_required(VERSION 3.15)
 
 # NOTE: Parsing the version like this is suboptimal but neccessary due to our release process:
 # https://github.com/KhronosGroup/Vulkan-Headers/pull/346
@@ -36,11 +36,32 @@ function(vlk_get_header_version)
 endfunction()
 vlk_get_header_version()
 
-project(VULKAN_HEADERS LANGUAGES C VERSION ${VK_VERSION_STRING})
+project(VULKAN_HEADERS LANGUAGES C CXX VERSION ${VK_VERSION_STRING})
 
 add_library(Vulkan-Headers INTERFACE)
 add_library(Vulkan::Headers ALIAS Vulkan-Headers)
 target_include_directories(Vulkan-Headers INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+if (MSVC AND (MSVC_VERSION GREATER_EQUAL "1934") OR
+    CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16.0" OR
+    CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0")
+    set(COMPILER_SUPPORTS_CXX_MODULES TRUE)
+endif()
+
+
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND COMPILER_SUPPORTS_CXX_MODULES)
+    add_library(Vulkan-Module)
+    add_library(Vulkan::VulkanHppModule ALIAS Vulkan-Module)
+    target_sources(Vulkan-Module
+        PUBLIC
+            FILE_SET module
+                TYPE CXX_MODULES
+                BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan/vulkan.cppm"
+    )
+    target_compile_features(Vulkan-Module PUBLIC cxx_std_20)
+    target_link_libraries(Vulkan-Module PUBLIC Vulkan-Headers)
+endif ()
 
 if (CMAKE_VERSION VERSION_LESS "3.21")
     # https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
@@ -65,8 +86,16 @@ if (VULKAN_HEADERS_ENABLE_INSTALL)
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION "${CMAKE_INSTALL_DATADIR}/vulkan" USE_SOURCE_PERMISSIONS)
 
     set_target_properties(Vulkan-Headers PROPERTIES EXPORT_NAME "Headers")
-
     install(TARGETS Vulkan-Headers EXPORT VulkanHeadersConfig INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND COMPILER_SUPPORTS_CXX_MODULES)
+        install(TARGETS Vulkan-Module
+            EXPORT VulkanHeadersConfig
+            FILE_SET module
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/include/vulkan"
+        )
+    endif()
+
     install(EXPORT VulkanHeadersConfig NAMESPACE "Vulkan::" DESTINATION "share/cmake/VulkanHeaders")
 
     set(version_config "${CMAKE_CURRENT_BINARY_DIR}/generated/VulkanHeadersConfigVersion.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,14 +88,6 @@ if (VULKAN_HEADERS_ENABLE_INSTALL)
     set_target_properties(Vulkan-Headers PROPERTIES EXPORT_NAME "Headers")
     install(TARGETS Vulkan-Headers EXPORT VulkanHeadersConfig INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND COMPILER_SUPPORTS_CXX_MODULES)
-        install(TARGETS Vulkan-Module
-            EXPORT VulkanHeadersConfig
-            FILE_SET module
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/include/vulkan"
-        )
-    endif()
-
     install(EXPORT VulkanHeadersConfig NAMESPACE "Vulkan::" DESTINATION "share/cmake/VulkanHeaders")
 
     set(version_config "${CMAKE_CURRENT_BINARY_DIR}/generated/VulkanHeadersConfigVersion.cmake")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ add_test(NAME integration.add_subdirectory
         --build-and-test ${CMAKE_CURRENT_LIST_DIR}/integration
                          ${CMAKE_CURRENT_BINARY_DIR}/add_subdirectory
         --build-generator ${CMAKE_GENERATOR}
-        --build-options -DFIND_PACKAGE_TESTING=OFF
+        --build-options -DFIND_PACKAGE_TESTING=OFF -DVULKAN_HEADERS_ENABLE_MODULE=OFF
 )
 
 set(test_install_dir "${CMAKE_CURRENT_BINARY_DIR}/install")


### PR DESCRIPTION
Added a new `IMPORTED` target and CMake library, `Vulkan::VulkanHppModule` that consumers can link against, to transparently use `import vulkan_hpp;`
- Avoids users having to [set the library up themselves](https://github.com/KhronosGroup/Vulkan-Hpp?tab=readme-ov-file#usage-with-cmake)
- Code mostly derived from [CMake's own tests](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Tests/RunCMake/CXXModules/examples/export-with-headers-install/CMakeLists.txt)
- Guarded this target behind a version test requiring at least CMake version 3.28 