### PR TITLE
Makefile to import generated scripts and headers when doing a spec update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,108 @@
+# Copyright 2024 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Makefile to update external files generated in other repositories when
+# a public specification update is done.
+
+# Needed to get the right version of test, apparently
+SHELL  = /bin/bash
+
+REVISION = 999
+
+# Location of other repository clones
+GIT	 = ..
+SPEC	 = $(GIT)/Vulkan-Docs
+HPP	 = $(GIT)/Vulkan-Hpp
+REGISTRY = $(GIT)/registry/vulkan
+
+update: consistency-check create-branch update-files push-branch
+
+# Working branch for the update, and a test if it exists
+BRANCH = update-$(REVISION)
+
+# Switch to new branch which will contain the update
+create-branch: consistency-check
+	git switch -q main
+	git pull -q
+	# If branch already exists, do nothing
+	@if test `git branch -l $(BRANCH) | wc -l` == 1 ; then \
+	    echo "Branch $(BRANCH) already exists" ; \
+	    git switch $(BRANCH) ; \
+	else \
+	    echo "Creating branch $(BRANCH)" ; \
+	    git switch -c $(BRANCH) ; \
+	fi
+
+# Update headers and scripts in the new branch
+update-files: remove-files update-headers update-scripts
+
+# Vulkan SC Vulkan-Hpp headers not published in the Vulkan-Headers repository
+SCHPPFILES = \
+    include/vulkan/vulkansc.hpp \
+    include/vulkan/vulkansc.cppm \
+    include/vulkan/vulkansc_*.hpp
+
+update-headers:
+	if test ! -d $(SPEC)/gen/include/ ; then \
+	    echo "No C header file source directory $(SPEC)/gen/include" ; \
+	    exit 1 ; \
+	fi
+	if test ! -d $(HPP)/vulkan ; then \
+	    echo "No C++ header file source directory $(HPP)/vulkan" ; \
+	    exit 1 ; \
+	fi
+	cp -r $(SPEC)/gen/include/* include/
+	cp -r $(HPP)/vulkan/* include/vulkan/
+	rm -f $(SCHPPFILES)
+
+# Top-level scripts / XML
+SCRIPTS = \
+    $(SPEC)/scripts/cgenerator.py \
+    $(SPEC)/scripts/generator.py \
+    $(SPEC)/scripts/parse_dependency.py \
+    $(SPEC)/scripts/reg.py \
+    $(SPEC)/scripts/stripAPI.py \
+    $(SPEC)/scripts/apiconventions.py \
+    $(SPEC)/scripts/vkconventions.py \
+    $(SPEC)/xml/vk.xml \
+    $(SPEC)/xml/video.xml \
+    $(REGISTRY)/specs/1.3-extensions/validation/validusage.json
+
+# Scripts in registry/spec_tools
+SCRIPT_TOOLS = \
+    $(SPEC)/scripts/spec_tools/conventions.py \
+    $(SPEC)/scripts/spec_tools/util.py
+
+# Profiles
+PROFILES = \
+    $(wildcard $(SPEC)/xml/profiles/*)
+
+update-scripts:
+	cp $(SCRIPTS) registry/
+	cp $(PROFILES) registry/profiles/
+	cp $(SCRIPT_TOOLS) registry/spec_tools/
+
+# To ensure updates are caught, old versions of installed files are
+# removed.
+
+# Files in include/ to keep
+HEADERS_KEEP = \
+    include/vulkan/vk_icd.h \
+    include/vulkan/vk_layer.h
+
+remove-files:
+	rm -rf $(filter-out $(HEADERS_KEEP), $(wildcard include/vulkan/*))
+	rm -rf include/vk_video
+	rm -rf registry
+	mkdir include/vk_video registry registry/profiles registry/spec_tools
+
+# Once the branch is updated, push it to upstream
+# This does not actually push it for safety reasons
+push-branch:
+	@echo Verify that all new files are 'git add'ed and obsolete files removed, then:
+	@echo git commit -m \"Update for Vulkan-Docs 1.3.$(REVISION)\"
+	@echo git push --set-upstream origin $(BRANCH)
+	@echo git switch main
+
+consistency-check:
+	@if test $(REVISION) = 999 ; then echo "Must specify explicit REVISION= in make invocation" ; exit 1 ; fi

--- a/Makefile.release
+++ b/Makefile.release
@@ -1,8 +1,8 @@
 # Copyright 2024 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Makefile to update external files generated in other repositories when
-# a public specification update is done.
+# Makefile.release - update external files generated in Vulkan spec
+# repository when a public specification update is done.
 
 # Needed to get the right version of test, apparently
 SHELL  = /bin/bash
@@ -15,13 +15,13 @@ SPEC	 = $(GIT)/Vulkan-Docs
 HPP	 = $(GIT)/Vulkan-Hpp
 REGISTRY = $(GIT)/registry/vulkan
 
-update: consistency-check create-branch update-files push-branch
+update: version-check create-branch update-files push-branch
 
 # Working branch for the update, and a test if it exists
 BRANCH = update-$(REVISION)
 
 # Switch to new branch which will contain the update
-create-branch: consistency-check
+create-branch: version-check
 	git switch -q main
 	git pull -q
 	# If branch already exists, do nothing
@@ -55,7 +55,7 @@ update-headers:
 	cp -r $(HPP)/vulkan/* include/vulkan/
 	rm -f $(SCHPPFILES)
 
-# Top-level scripts / XML
+# Top-level scripts / XML to install
 SCRIPTS = \
     $(SPEC)/scripts/cgenerator.py \
     $(SPEC)/scripts/generator.py \
@@ -68,12 +68,12 @@ SCRIPTS = \
     $(SPEC)/xml/video.xml \
     $(REGISTRY)/specs/1.3-extensions/validation/validusage.json
 
-# Scripts in registry/spec_tools
+# Scripts in registry/spec_tools to install
 SCRIPT_TOOLS = \
     $(SPEC)/scripts/spec_tools/conventions.py \
     $(SPEC)/scripts/spec_tools/util.py
 
-# Profiles
+# Profiles to install
 PROFILES = \
     $(wildcard $(SPEC)/xml/profiles/*)
 
@@ -104,5 +104,5 @@ push-branch:
 	@echo git push --set-upstream origin $(BRANCH)
 	@echo git switch main
 
-consistency-check:
+version-check:
 	@if test $(REVISION) = 999 ; then echo "Must specify explicit REVISION= in make invocation" ; exit 1 ; fi

--- a/registry/stripAPI.py
+++ b/registry/stripAPI.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright 2023 The Khronos Group Inc.
+# Copyright 2023-2024 The Khronos Group Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse


### PR DESCRIPTION
Motivated by recent problems building the SC 1.0.15 spec update - will import to VulkanSC-Headers and tweak once it's proven out for Vulkan-Headers.

The Makefile may need to be modified when directory structure is changed or new scripts or headers are added.
