### PR TITLE
GN build: Define VK_USE_PLATFORM_XLIB_KHR

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -13,7 +13,10 @@ config("vulkan_headers_config") {
     defines += [ "VK_USE_PLATFORM_WIN32_KHR" ]
   }
   if (defined(vulkan_use_x11) && vulkan_use_x11) {
-    defines += [ "VK_USE_PLATFORM_XCB_KHR" ]
+    defines += [
+      "VK_USE_PLATFORM_XCB_KHR",
+      "VK_USE_PLATFORM_XLIB_KHR",
+    ]
   }
   if (defined(vulkan_use_wayland) && vulkan_use_wayland) {
     defines += [ "VK_USE_PLATFORM_WAYLAND_KHR" ]


### PR DESCRIPTION
This is required to define vkCreateXlibSurfaceKHR, which is required by GTK4.

Depends on Dawn CL:
https://dawn-review.googlesource.com/c/dawn/+/229494

Needed to fix this Chromium issue:
https://g-issues.chromium.org/issues/345261080

<!-- Please note when contributing what files this repository actually is responsible for.

Vulkan-Headers exists as a publishing mechanism for headers and related material sourced from multiple other repositories. If you have a problem with that material, it should *not* be reported here, but in the appropriate repository:

This repository is responsible for the following files

* BUILD.gn
* BUILD.md
* CMakeLists.txt
* tests/*
* CODE_OF_CONDUCT.md
* LICENSE.txt
* README.md
* Non-API headers
  * include/vulkan/vk_icd.h
  * include/vulkan/vk_layer.h

-->
