### PR TITLE
ignore Jetbrains config directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@
 __pycache__
 *.pyc
 build
+cmake-build-*/
+.idea/
 .vscode/
 **/.*.swp


### PR DESCRIPTION
Basic Jetbrains (CLion) setup creates .idea/, cmake-build-debug/, cmake-build-release/ directories.