### PR TITLE
Remove VVL workaround

### DIFF
--- a/registry/base_generator.py
+++ b/registry/base_generator.py
@@ -463,10 +463,6 @@ class BaseGenerator(OutputGenerator):
                 handle.device = next_parent.name == 'VkDevice'
                 next_parent = next_parent.parent
 
-        # This use to be Queues.ALL, but there is no real concept of "all"
-        # Found this just needs to be something non-None
-        maxSyncSupport.queues = Queues.TRANSFER
-
         maxSyncSupport.stages = self.vk.bitmasks['VkPipelineStageFlagBits2'].flags
         maxSyncEquivalent.accesses = self.vk.bitmasks['VkAccessFlagBits2'].flags
         maxSyncEquivalent.stages = self.vk.bitmasks['VkPipelineStageFlagBits2'].flags


### PR DESCRIPTION
Fixes validation of host stage in Vulkan-ValidationLayers.

The initial intention of the workaround was to fix a crash with None value, but it also introduced side effect when HOST_STAGE is considered to be part of TRANSFER_QUEUE, which led to incorrect validation of HOST_STAGE.

The None value (no queue) in VVL scripts appears as the result that HOST_STAGE is not assigned to any queue. VVL can handle this with explicit check without using special values.
