### PR TITLE
CMake: Don't install C++ module headers if module build is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,11 +109,18 @@ if (VULKAN_HEADERS_ENABLE_INSTALL)
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-    # Preserve source permissions https://github.com/KhronosGroup/Vulkan-Headers/issues/336
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION "${CMAKE_INSTALL_DATADIR}/vulkan" USE_SOURCE_PERMISSIONS)
-
+    if(VULKAN_HEADERS_ENABLE_MODULE)
+        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+	install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        # Preserve source permissions https://github.com/KhronosGroup/Vulkan-Headers/issues/336
+        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION "${CMAKE_INSTALL_DATADIR}/vulkan" USE_SOURCE_PERMISSIONS)
+    else()
+	# Don't install C++ module files if modules aren't enabled
+        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vk_video" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} PATTERN "*.cppm" EXCLUDE)
+        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} PATTERN "*.cppm" EXCLUDE)
+        # Preserve source permissions https://github.com/KhronosGroup/Vulkan-Headers/issues/336
+        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/registry" DESTINATION "${CMAKE_INSTALL_DATADIR}/vulkan" USE_SOURCE_PERMISSIONS PATTERN "*.cppm" EXCLUDE)
+    endif()
 
     set_target_properties(Vulkan-Headers PROPERTIES EXPORT_NAME "Headers")
     install(TARGETS Vulkan-Headers


### PR DESCRIPTION
Currently we are installing `.cppm` files even if `VULKAN_HEADERS_ENABLE_MODULE` is off.

Right now in Gentoo we are just manually deleting the files, would be nice to have a clean solution.

Let me know if there's a way to prevent the copy paste here.