### PR TITLE
GN Build: Add a way to skip xlib includes

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -13,10 +13,10 @@ config("vulkan_headers_config") {
     defines += [ "VK_USE_PLATFORM_WIN32_KHR" ]
   }
   if (defined(vulkan_use_x11) && vulkan_use_x11) {
-    defines += [
-      "VK_USE_PLATFORM_XCB_KHR",
-      "VK_USE_PLATFORM_XLIB_KHR",
-    ]
+    defines += [ "VK_USE_PLATFORM_XCB_KHR" ]
+    if (!defined(vulkan_no_xlib_headers) || !vulkan_no_xlib_headers) {
+      defines += [ "VK_USE_PLATFORM_XLIB_KHR" ]
+    }
   }
   if (defined(vulkan_use_wayland) && vulkan_use_wayland) {
     defines += [ "VK_USE_PLATFORM_WAYLAND_KHR" ]


### PR DESCRIPTION
Xlib headers `#define` really common names and are problematic when included in various places.

0f0cfd88d7e6ece3ca6456df692f0055bde94be7 added VK_USE_PLATFORM_XLIB_KHR when vulkan_use_x11=true, alongside the pre-existing VK_USE_PLATFORM_XCB_KHR.  In this change, VK_USE_PLATFORM_XLIB_KHR is only added if vulkan_no_xlib_headers=false, so projects can opt out of xlib includes.