### PR TITLE
Change to dual license on static Vulkan headers

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,12 +1,13 @@
-Copyright 2015-2023 The Khronos Group Inc.
+Copyright 2015-2026 The Khronos Group Inc.
 
 Files in this repository fall under one of these licenses:
 
 - `Apache-2.0`
 - `MIT`
 
-Note: With the exception of `parse_dependency.py` the files using `MIT` license
-also fall under `Apache-2.0`. Example:
+Note: With the exception of `parse_dependency.py`, which is based on an
+external file, files using the `MIT` license also fall under `Apache-2.0`.
+Example:
 
 ```
 SPDX-License-Identifier: Apache-2.0 OR MIT

--- a/include/vulkan/vk_icd.h
+++ b/include/vulkan/vk_icd.h
@@ -2,8 +2,7 @@
  * Copyright 2015-2023 The Khronos Group Inc.
  * Copyright 2015-2023 Valve Corporation
  * Copyright 2015-2023 LunarG, Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 #pragma once
 

--- a/include/vulkan/vk_layer.h
+++ b/include/vulkan/vk_layer.h
@@ -2,8 +2,7 @@
  * Copyright 2015-2023 The Khronos Group Inc.
  * Copyright 2015-2023 Valve Corporation
  * Copyright 2015-2023 LunarG, Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 #pragma once
 


### PR DESCRIPTION
Based on feedback here and internal Vulkan issue 4883, changing the license on the static headers vk_icd.h and vk_layer.h to dual Apache-2.0 OR MIT, matching the generated headers.

Closes #605