### PR TITLE
Update CMake min to 3.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,12 @@ jobs:
     strategy:
       matrix:
           compiler: [ clang, clang-cl ]
+          cmake-version: [ '3.28.3', 'latest' ]
     steps:
         - uses: actions/checkout@v7
+        - uses: lukka/get-cmake@latest
+          with:
+            cmakeVersion: ${{ matrix.cmake-version }}
         - uses: ilammy/msvc-dev-cmd@v1
         - run: |
             cmake -S . -B build `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        cmake-version: [ '3.22.1', 'latest']
+        cmake-version: [ '3.28.3', 'latest']
     steps:
       - uses: actions/checkout@v7
       - uses: lukka/get-cmake@latest
@@ -39,7 +39,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
-        cmake-version: [ '3.22.1', 'latest']
+        cmake-version: [ '3.28.3', 'latest']
     steps:
       - uses: actions/checkout@v7
       - uses: lukka/get-cmake@latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ~~~
-cmake_minimum_required(VERSION 3.22.1)
+cmake_minimum_required(VERSION 3.28.3)
 
 include(CMakeDependentOption)
-
 
 # NOTE: Parsing the version like this is suboptimal but neccessary due to our release process:
 # https://github.com/KhronosGroup/Vulkan-Headers/pull/346
 #
-# As shown a more robust approach would be just to add basic test code to check the project version.
-function(vlk_get_header_version)
+# A better approach would be just to add basic test code to check the project version.
+# IE set the version in the CMakeLists.txt and then check that the version is correct in a test.
+# Avoids file parsing on every single configuration and is more robust to changes in the header file.
+block(PROPAGATE VK_VERSION_STRING)
     set(vulkan_core_header_file "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan/vulkan_core.h")
     if (NOT EXISTS ${vulkan_core_header_file})
         message(FATAL_ERROR "Couldn't find vulkan_core.h!")
@@ -35,9 +36,8 @@ function(vlk_get_header_version)
         message(FATAL_ERROR "Couldn't get the patch version")
     endif()
 
-    set(VK_VERSION_STRING "${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}" PARENT_SCOPE)
-endfunction()
-vlk_get_header_version()
+    set(VK_VERSION_STRING "${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}")
+endblock()
 
 project(VULKAN_HEADERS LANGUAGES C CXX VERSION ${VK_VERSION_STRING})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,3 +34,70 @@ add_test(NAME integration.find_package
 
 # Installing comes before testing
 set_tests_properties(integration.find_package PROPERTIES DEPENDS integration.install)
+
+# Verify that every public header compiles standalone (i.e. that each one includes
+# everything it needs and doesn't just rely on being pulled in after some other header).
+#
+# The header list is globbed so newly added headers are picked up automatically. Headers
+# that are known not to be self-contained are excluded from compilation individually via
+# SKIP_LINTING below, rather than omitted from the FILE_SET, so they still show up here
+# and don't silently fall out of the verification as the headers evolve.
+file(GLOB_RECURSE vk_headers_verify_headers CONFIGURE_DEPENDS LIST_DIRECTORIES false
+    "${VULKAN_HEADERS_SOURCE_DIR}/include/vulkan/*.h"
+    "${VULKAN_HEADERS_SOURCE_DIR}/include/vulkan/*.hpp"
+    "${VULKAN_HEADERS_SOURCE_DIR}/include/vk_video/*.h"
+)
+list(SORT vk_headers_verify_headers)
+
+add_library(vk_headers_verify INTERFACE)
+set_target_properties(vk_headers_verify PROPERTIES LINKER_LANGUAGE C)
+target_sources(vk_headers_verify INTERFACE
+    FILE_SET HEADERS
+    BASE_DIRS "${VULKAN_HEADERS_SOURCE_DIR}/include"
+    FILES ${vk_headers_verify_headers}
+)
+
+# WSI headers (vulkan_win32.h, vulkan_xcb.h, vulkan_wayland.h, ...) are deliberately
+# skipped: vulkan.h itself includes their platform prerequisites (e.g. <windows.h>) before
+# including them, so they're sub-headers of vulkan.h, not standalone headers.
+set(vk_headers_verify_platform_headers
+    vulkan_android.h
+    vulkan_directfb.h
+    vulkan_fuchsia.h
+    vulkan_ggp.h
+    vulkan_ios.h
+    vulkan_macos.h
+    vulkan_metal.h
+    vulkan_ohos.h
+    vulkan_screen.h
+    vulkan_ubm.h
+    vulkan_vi.h
+    vulkan_wayland.h
+    vulkan_win32.h
+    vulkan_xcb.h
+    vulkan_xlib.h
+    vulkan_xlib_xrandr.h
+)
+
+# These files cannot be included on their own.
+set(vk_headers_verify_detail_headers
+    vulkan_beta.h
+    vulkan_enums.hpp
+    vulkan_funcs.hpp
+    vulkan_handles.hpp
+    vulkan_structs.hpp
+    vulkan_to_string.hpp
+)
+
+foreach(header IN LISTS vk_headers_verify_platform_headers vk_headers_verify_detail_headers)
+    set_source_files_properties("${VULKAN_HEADERS_SOURCE_DIR}/include/vulkan/${header}" PROPERTIES SKIP_LINTING ON)
+endforeach()
+
+set_target_properties(vk_headers_verify PROPERTIES VERIFY_INTERFACE_HEADER_SETS ON)
+
+# CMake always sets EXCLUDE_FROM_ALL on the generated all_verify_interface_header_sets
+# target, so a plain build never compiles it; this explicit --target build is the only
+# way to run the verification.
+add_test(NAME headers.verify_standalone
+    COMMAND ${CMAKE_COMMAND} --build ${VULKAN_HEADERS_BINARY_DIR} --target all_verify_interface_header_sets --config $<CONFIG>
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,23 +38,31 @@ set_tests_properties(integration.find_package PROPERTIES DEPENDS integration.ins
 # Verify that every public header compiles standalone (i.e. that each one includes
 # everything it needs and doesn't just rely on being pulled in after some other header).
 #
-# The header list is globbed so newly added headers are picked up automatically. Headers
-# that are known not to be self-contained are excluded from compilation individually via
-# SKIP_LINTING below, rather than omitted from the FILE_SET, so they still show up here
-# and don't silently fall out of the verification as the headers evolve.
-file(GLOB_RECURSE vk_headers_verify_headers CONFIGURE_DEPENDS LIST_DIRECTORIES false
-    "${VULKAN_HEADERS_SOURCE_DIR}/include/vulkan/*.h"
-    "${VULKAN_HEADERS_SOURCE_DIR}/include/vulkan/*.hpp"
-    "${VULKAN_HEADERS_SOURCE_DIR}/include/vk_video/*.h"
+# The header list is globbed so newly added headers are picked up automatically, in any
+# subdirectory of include/. Headers that are known not to be self-contained are excluded
+# from compilation individually via SKIP_LINTING below, rather than omitted from the
+# FILE_SET, so they still show up here and don't silently fall out of the verification as
+# the headers evolve.
+file(GLOB_RECURSE vk_headers_verify_c_headers CONFIGURE_DEPENDS LIST_DIRECTORIES false
+    "${VULKAN_HEADERS_SOURCE_DIR}/include/*.h"
 )
-list(SORT vk_headers_verify_headers)
+file(GLOB_RECURSE vk_headers_verify_cxx_headers CONFIGURE_DEPENDS LIST_DIRECTORIES false
+    "${VULKAN_HEADERS_SOURCE_DIR}/include/*.hpp"
+)
+list(SORT vk_headers_verify_c_headers)
+list(SORT vk_headers_verify_cxx_headers)
+
+# Set LANGUAGE explicitly per header instead of leaving it for CMake to deduce: .h is an
+# extension both C and CXX claim, so an undeduced .h header could silently end up compiled
+# as C++ instead of being checked against a C compiler.
+set_source_files_properties(${vk_headers_verify_c_headers} PROPERTIES LANGUAGE C)
+set_source_files_properties(${vk_headers_verify_cxx_headers} PROPERTIES LANGUAGE CXX)
 
 add_library(vk_headers_verify INTERFACE)
-set_target_properties(vk_headers_verify PROPERTIES LINKER_LANGUAGE C)
 target_sources(vk_headers_verify INTERFACE
     FILE_SET HEADERS
     BASE_DIRS "${VULKAN_HEADERS_SOURCE_DIR}/include"
-    FILES ${vk_headers_verify_headers}
+    FILES ${vk_headers_verify_c_headers} ${vk_headers_verify_cxx_headers}
 )
 
 # WSI headers (vulkan_win32.h, vulkan_xcb.h, vulkan_wayland.h, ...) are deliberately

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,17 +79,27 @@ set(vk_headers_verify_platform_headers
     vulkan_xlib_xrandr.h
 )
 
-# These files cannot be included on their own.
+# vulkan_beta.h cannot be included on its own: it relies on types (VkStructureType,
+# VkBool32, ...) that are defined in vulkan_core.h, which vulkan.h includes first.
 set(vk_headers_verify_detail_headers
     vulkan_beta.h
+)
+
+# None of the *.hpp headers below are designed to be included on their own either:
+# they're pulled in automatically by including vulkan.hpp (vulkan_hpp_macros.hpp,
+# vulkan_enums.hpp, vulkan_to_string.hpp, vulkan_handles.hpp, vulkan_structs.hpp, and
+# vulkan_funcs.hpp, alongside vulkan.h), so verifying vulkan.hpp standalone already
+# covers them and there's no need to verify them individually.
+set(vk_headers_verify_hpp_headers
     vulkan_enums.hpp
     vulkan_funcs.hpp
     vulkan_handles.hpp
+    vulkan_hpp_macros.hpp
     vulkan_structs.hpp
     vulkan_to_string.hpp
 )
 
-foreach(header IN LISTS vk_headers_verify_platform_headers vk_headers_verify_detail_headers)
+foreach(header IN LISTS vk_headers_verify_platform_headers vk_headers_verify_detail_headers vk_headers_verify_hpp_headers)
     set_source_files_properties("${VULKAN_HEADERS_SOURCE_DIR}/include/vulkan/${header}" PROPERTIES SKIP_LINTING ON)
 endforeach()
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # ~~~
-cmake_minimum_required(VERSION 3.22.1)
+cmake_minimum_required(VERSION 3.28.3)
 
 project(API LANGUAGES C CXX)
 


### PR DESCRIPTION
Ubuntu 24.04 LTS (noble) packages cmake 3.28.3, only the 2 latest LTS releases are supported,
requiring 3.28 keeps compatibility with all currently supported Ubuntu LTS versions.

Utilize new block() functionality instead of function

Utilize VERIFY_INTERFACE_HEADER_SETS to ensure header files can compile correctly on their own. (Test code only).

