### PR TITLE
Update Vulkan named module in test

### DIFF
--- a/tests/vk_hpp_module.cpp
+++ b/tests/vk_hpp_module.cpp
@@ -5,7 +5,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import vulkan_hpp;
+import vulkan;
 
 int test_version()
 {


### PR DESCRIPTION
The C++ named module `vulkan_hpp` was renamed back to `vulkan` in [v1.4.334](https://github.com/KhronosGroup/Vulkan-Hpp#v14334).